### PR TITLE
[Feat/#14] 영업 활동 등록 페이지 및 기능 구현

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -3,6 +3,7 @@ import MainView from '../views/main/MainView.vue';
 import LoginView from '../views/auth/LoginView.vue';
 import SignUpView from '../views/auth/SignUpView.vue';
 import CalendarView from '../views/calendar/CalendarView.vue';
+import ActView from '../views/act/ActView.vue';
 import NotFoundView from '../views/NotFoundView.vue';
 
 
@@ -28,6 +29,12 @@ const routes = [
         path: "/calendar",
         name: 'Calendar',
         component: CalendarView
+    },
+
+    {
+        path: "/act",
+        name: 'Act',
+        component: ActView
     },
 
     { 

--- a/src/views/act/ActView.vue
+++ b/src/views/act/ActView.vue
@@ -1,0 +1,197 @@
+<template>
+  <v-container fluid class="form-container">
+    <v-row justify="end">
+      <v-col cols="12" lg="12" offset-md="1">
+        <UiParentCard title="영업활동 등록">
+          <v-form ref="form" v-model="valid" lazy-validation>
+            <v-text-field
+              label="영업기회"
+              v-model="act.leadNo"
+              outlined
+              :rules="[v => !!v || '영업기회를 입력하세요.']"
+              required
+            ></v-text-field>
+
+            <v-text-field
+              label="활동명"
+              v-model="act.name"
+              outlined
+              :rules="[v => !!v || '활동명을 입력하세요.']"
+              required
+            ></v-text-field>
+
+            <v-select
+              label="활동분류"
+              v-model="act.cls"
+              :items="actStatusOptions"
+              outlined
+              :rules="[v => !!v || '활동분류를 선택하세요.']"
+              required
+            ></v-select>
+
+            <v-text-field
+              label="활동목적"
+              v-model="act.purpose"
+              outlined
+              :rules="[v => !!v || '활동목적을 입력하세요.']"
+              required
+            ></v-text-field>
+
+            <v-text-field
+              v-model="act.actDate"
+              label="활동일자"
+              type="date"
+              :rules="[v => !!v || '활동일자를 선택하세요.']"
+              outlined
+              required
+            ></v-text-field>
+
+            <v-row>
+              <v-col>
+                <v-select
+                  label="시작 시간"
+                  v-model="act.startTime"
+                  :items="timeOptions"
+                  outlined
+                  :rules="[v => !!v || '시작 시간을 선택하세요.']"
+                  required
+                ></v-select>
+              </v-col>
+              <v-col>
+                <v-select
+                  label="종료 시간"
+                  v-model="act.endTime"
+                  :items="timeOptions"
+                  outlined
+                  :rules="[v => !!v || '종료 시간을 선택하세요.']"
+                  required
+                ></v-select>
+              </v-col>
+            </v-row>
+
+            <v-switch label="완료" v-model="act.completeYn" inset></v-switch>
+
+            <v-textarea label="계획내용" v-model="act.planContent" outlined></v-textarea>
+            <v-textarea label="활동내용" v-model="act.actContent" outlined></v-textarea>
+
+            <v-btn color="primary" @click="submitForm">저장</v-btn>
+          </v-form>
+        </UiParentCard>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { ref } from 'vue';
+import axios from 'axios';
+import { useRouter } from 'vue-router';
+import UiParentCard from './UiParentCard.vue';
+
+export default {
+  components: {
+    UiParentCard
+  },
+  setup() {
+    const router = useRouter();
+
+    const valid = ref(false);
+    const form = ref(null);
+    const act = ref({
+      leadNo: 1, // 영업기회(하드코딩)
+      name: '',
+      cls: '',
+      purpose: '',
+      actDate: null,
+      startTime: null,
+      endTime: null,
+      completeYn: false,
+      planContent: '',
+      actContent: ''
+    });
+
+    const actStatusOptions = ref([
+      "MEETING",
+      "PRODUCT_INTRO",
+      "NEGOTIATION",
+      "CONTRACT",
+      "ESITIMATE",
+      "PROPOSAL"
+    ]);
+
+    const timeOptions = ref([
+      "09:00", "10:00", "11:00", "12:00", "13:00",
+      "14:00", "15:00", "16:00", "17:00", "18:00", "19:00"
+    ]);
+
+    const resetForm = () => {
+      act.value = {
+        leadNo: 1, 
+        name: '',
+        cls: '',
+        purpose: '',
+        actDate: null,
+        startTime: null,
+        endTime: null,
+        completeYn: false,
+        planContent: '',
+        actContent: ''
+      };
+    };
+
+    const submitForm = async () => {
+      console.log("act 데이터 확인: ", act.value);
+      console.log("actContent:", act.value.actContent); 
+      console.log("planContent:", act.value.planContent);
+
+
+      if (form.value.validate()) {
+        try {
+          const response = await axios.post('http://localhost:8080/api/acts', {
+            leadNo: act.value.leadNo,
+            name: act.value.name,
+            cls: act.value.cls,
+            purpose: act.value.purpose,
+            actDate: act.value.actDate,
+            startTime: act.value.startTime,
+            endTime: act.value.endTime,
+            completeYn: act.value.completeYn ? "Y" : "N", 
+            planContent: act.value.planContent,
+            actContent: act.value.actContent,
+            calendarNo: 1, // TODO: 유저 캘린더 번호로 설정 필요
+          });
+          // console.log("등록 성공:", response.data);
+
+          resetForm();
+
+          router.push('/calendar');
+
+        } catch (error) {
+          console.error("등록 실패:", error);
+        }
+      } else {
+        alert("필수 입력 필드를 확인해주세요.");
+      }
+    };
+
+    return {
+      form,
+      valid,
+      act,
+      actStatusOptions,
+      timeOptions,
+      submitForm
+    };
+  }
+};
+</script>
+
+<style scoped>
+.form-container {
+  position: absolute;
+  right: 0;
+  width: 80%;
+  padding: 20px;
+  border-radius: 8px;
+}
+</style>

--- a/src/views/calendar/CalendarView.vue
+++ b/src/views/calendar/CalendarView.vue
@@ -77,6 +77,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import axios from 'axios';
+import './calendar.css'
 
 export default defineComponent({
 	components: {
@@ -121,8 +122,28 @@ export default defineComponent({
 	},
 	created() {
 		this.fetchTodos();
+		this.fetchActs();
 	},
 	methods: {
+		async fetchActs() {
+			try {
+				const response = await axios.get('http://localhost:8080/api/acts');
+				const acts = response.data.result;
+
+				const calendarApi = this.$refs.calendar.getApi();
+				acts.forEach(act => {
+					calendarApi.addEvent({
+						id: act.no,
+						title: act.name,
+						start: act.actDate,
+						allDay: true,
+						classNames: ['act-event'],
+					});
+				});
+			} catch (e) {
+				console.error(e);
+			}
+		},
 		async fetchTodos() {
 			try {
 				const response = await axios.get('http://localhost:8080/api/todos');
@@ -135,6 +156,7 @@ export default defineComponent({
 						title: todo.title,
 						start: todo.dueDate,
 						allDay: true,
+						classNames: ['todo-event'],
 					});
 				});
 			} catch (e) {
@@ -218,16 +240,16 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.calendar-container{
+.calendar-container {
 	position: relative;
 }
 
-.select-item{
+.select-item {
 	margin-bottom: 20px;
 	width: 200px;
 }
 
-.alert-fixed{
+.alert-fixed {
 	position: fixed;
 	top: 20px;
 	left: 50%;

--- a/src/views/calendar/calendar.css
+++ b/src/views/calendar/calendar.css
@@ -1,0 +1,41 @@
+/* 할 일 */
+.todo-event {
+    background-color: #eca4b4;
+    color: white;
+    font-size: 14px;
+    border: none;
+}
+.todo-event:hover {
+    background-color: #cf8394;
+    cursor: pointer;
+    border: none;
+}
+
+/* 영업활동 */
+.act-event {
+    background-color: #76b2d4;
+    color: white;
+    font-size: 14px;
+    border: none;
+}
+.act-event :hover {
+    background-color: #5991b1;
+    cursor: pointer;
+    border: none;
+}
+
+/* 이벤트 제목 스타일 */
+.fc-event-title {
+    font-weight: bold;
+    color: #fff;
+}
+
+/* 이벤트 제목 컨테이너 스타일 */
+.fc-event-title-container {
+    padding: 2px 5px;
+    text-align: center;
+}
+
+.fc-toolbar button:hover {
+    background-color: #2a4887;
+}


### PR DESCRIPTION
## 💬 작업 내용 설명
- 영업 활동 등록 페이지 추가
- 영업 활동 등록 기능 구현
- 영업 활동 캘린더에 조회 되도록 구현
- 영업 활동 등록 시 유효성 검사 구현
- 캘린더 이벤트에 색상 등의 css 적용

<br>
<details>
  <summary> 영업 활동 등록 </summary>

![image](https://github.com/user-attachments/assets/8ee8ea54-61bf-4394-be07-36ae5e59d315)
</details>

<details>
  <summary> 유효성 </summary>

![image](https://github.com/user-attachments/assets/7d024cb1-aed7-4611-a724-9836d3e8579f)
</details>

<details>
  <summary> 전체 캘린더 </summary>
- 핑크색: todo
- 하늘색: act

![image](https://github.com/user-attachments/assets/439c18cb-57cc-4aac-a99e-2a4194800dad)
</details>

<br>

## #️⃣연관된  issue
close #14

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

<br>

## 📑To Reviewers

- 영업 활동 등록 제약조건 관련 오류 수정 예정
