### PR TITLE
[Feat/#31] sales 기본 페이지 구현 카드 형식으로 구현

### DIFF
--- a/src/router/MainRoutes.ts
+++ b/src/router/MainRoutes.ts
@@ -148,6 +148,11 @@ const MainRoutes = {
             component: () => import('@/views/apps/contract/ContractView.vue')
         },
         {
+            name: 'Sales',
+            path: '/apps/sales',
+            component: () => import('@/views/apps/sales/SalesView.vue')
+        },
+        {
             name: 'Act',
             path: '/apps/act',
             component: () => import('@/views/apps/calendar/act/FormCustom.vue')

--- a/src/views/apps/contract/ContractDetailView.vue
+++ b/src/views/apps/contract/ContractDetailView.vue
@@ -2,7 +2,6 @@
 <script>
 import axios from 'axios';
 import ContractModal from './ContractModal.vue';
-import vuetify from '@/plugins/vuetify';
 
 export default {
     components: { ContractModal },

--- a/src/views/apps/sales/SalesDetailView.vue
+++ b/src/views/apps/sales/SalesDetailView.vue
@@ -1,0 +1,168 @@
+<script>
+import axios from 'axios';
+import SalesModal from './SalesModal.vue';
+
+export default {
+    components: { SalesModal },
+    data() {
+        return {
+            sales: [],
+            showModal: false,
+            editedSale: {
+                salesNo: null,
+                salesCls: '',
+                salesDate: '',
+                taxCls: '',
+                surtaxYn: '',
+                productCount: 0,
+                supplyPrice: 0,
+                tax: 0,
+                price: 0,
+                expArrivalDate: '',
+                busiType: '',
+                busiTypeDetail: '',
+                note: '',
+                contractNo: '',
+            },
+            search: '',
+        };
+    },
+    mounted() {
+        this.fetchSales();
+    },
+    methods: {
+        async fetchSales() {
+            try {
+                const response = await axios.get('http://localhost:8080/api/sales');
+                this.sales = response.data.result;
+            } catch (error) {
+                console.error('매출 목록을 가져오는 데 실패했습니다:', error);
+            }
+        },
+        async deleteSale(salesNo) {
+            if (confirm('정말로 이 매출을 삭제하시겠습니까?')) {
+                try {
+                    await axios.delete(`http://localhost:8080/api/sales/${salesNo}`);
+                    this.fetchSales();
+                    alert('매출이 삭제되었습니다.');
+                } catch (error) {
+                    console.error('매출 삭제에 실패했습니다:', error);
+                    alert('매출 삭제에 실패했습니다.');
+                }
+            }
+        },
+        editSale(sale) {
+            this.editedSale = { ...sale };
+            this.showModal = true;
+        },
+        openModal() {
+            this.editedSale = {
+                salesNo: null,
+                salesCls: '',
+                salesDate: '',
+                taxCls: '',
+                surtaxYn: '',
+                productCount: 0,
+                supplyPrice: 0,
+                tax: 0,
+                price: 0,
+                expArrivalDate: '',
+                busiType: '',
+                busiTypeDetail: '',
+                note: '',
+                contractNo: '',
+            };
+            this.showModal = true;
+        },
+        closeModal() {
+            this.showModal = false;
+        },
+        async saveSale(sale) {
+            try {
+                if (sale.salesNo) {
+                    await axios.patch(`http://localhost:8080/api/sales/${sale.salesNo}`, sale);
+                } else {
+                    await axios.post('http://localhost:8080/api/sales', sale);
+                }
+                this.fetchSales();
+                this.closeModal();
+            } catch (error) {
+                console.error('매출 저장에 실패했습니다:', error);
+            }
+        },
+        openSalesInfo(sale) {
+            this.editedSale = { ...sale };
+            this.showModal = true; 
+        },
+    },
+};
+</script>
+
+<template>
+    <div>
+        <v-row>
+            <v-col cols="12" class="text-right">
+                <v-btn color="primary" @click="openModal" flat>
+                    <v-icon class="mr-2">mdi-account-multiple-plus</v-icon>매출 추가
+                </v-btn>
+            </v-col>
+        </v-row>
+        <v-row>
+            <v-col v-for="(sale, index) in sales" :key="index" cols="12" md="6">
+                <v-card @click="openSalesInfo(sale)" class="sales-card">
+                    <v-card-title class="sales-title">{{ sale.salesCls }}</v-card-title>
+                    <v-card-subtitle class="sales-subtitle">매출 번호: {{ sale.salesNo }}</v-card-subtitle>
+                    <v-card-text class="sales-text">
+                        <div>수량: <span class="highlight">{{ sale.productCount }}</span></div>
+                        <div>합계 금액: <span class="highlight">{{ sale.price.toLocaleString() }} 원</span></div>
+                        <div>사업 유형: <span class="highlight">{{ sale.busiType }}</span></div>
+                        <div>계약 번호: <span class="highlight">{{ sale.contractNo }}</span></div>
+                    </v-card-text>
+                </v-card>
+            </v-col>
+            <v-col v-if="sales.length === 0" cols="12">
+                <v-alert type="info">데이터가 없습니다.</v-alert>
+            </v-col>
+        </v-row>
+
+        <SalesModal
+            v-model="showModal"
+            :sale="editedSale"
+            @save="saveSale"
+            @close="closeModal"
+        />
+    </div>
+</template>
+
+<style scoped>
+.sales-card {
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    background-color: #f9f9f9; 
+    border: 1px solid #ddd; 
+    border-radius: 8px; 
+    padding: 16px; 
+    max-width: 500px; 
+    margin: 10px; 
+}
+.sales-card:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+}
+.sales-title {
+    font-size: 1.5rem; 
+    font-weight: bold; 
+    color: #0008a3c8; 
+}
+.sales-subtitle {
+    font-size: 1rem; 
+    color: #747474; 
+}
+.sales-text {
+    font-size: 0.9rem; 
+    color: #333; 
+}
+.highlight {
+    color: #747474; 
+}
+</style>

--- a/src/views/apps/sales/SalesModal.vue
+++ b/src/views/apps/sales/SalesModal.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-dialog v-model="isOpen" @close="handleClose" max-width="600px">
+    <v-card>
+      <v-card-title>
+        <span>{{ sale.salesNo ? '매출 수정' : '매출 추가' }}</span>
+      </v-card-title>
+      <v-card-text>
+        <v-form ref="form" v-model="valid" lazy-validation>
+          <v-text-field v-model="sale.salesCls" label="매출 구분" required />
+          <v-text-field v-model="sale.salesDate" label="매출일" type="date" required />
+          <v-text-field v-model="sale.taxCls" label="과세 구분" />
+          <v-text-field v-model="sale.surtaxYn" label="추가 세금 여부 (Y/N)" maxlength="1" />
+          <v-text-field v-model="sale.productCount" label="수량" type="number" />
+          <v-text-field v-model="sale.supplyPrice" label="공급가액" type="number" />
+          <v-text-field v-model="sale.tax" label="세액" type="number" />
+          <v-text-field v-model="sale.price" label="총 가격" type="number" />
+          <v-text-field v-model="sale.expArrivalDate" label="입고예정일" type="date" />
+          <v-text-field v-model="sale.busiType" label="사업 유형" />
+          <v-text-field v-model="sale.busiTypeDetail" label="사업 유형 상세" />
+          <v-textarea v-model="sale.note" label="비고" />
+          <v-text-field v-model="sale.contractNo" label="계약번호" />
+        </v-form>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn @click="saveSale">저장</v-btn>
+        <v-btn @click="handleClose">취소</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  props: {
+    value: Boolean,
+    sale: {
+      type: Object,
+      default: () => ({
+        salesNo: null,
+        salesCls: '',
+        salesDate: '',
+        taxCls: '',
+        surtaxYn: '',
+        productCount: 0,
+        supplyPrice: 0,
+        tax: 0,
+        price: 0,
+        expArrivalDate: '',
+        busiType: '',
+        busiTypeDetail: '',
+        note: '',
+        contractNo: '',
+      }),
+    },
+  },
+  data() {
+    return {
+      valid: false,
+    };
+  },
+  computed: {
+    isOpen: {
+      get() {
+        return this.value;
+      },
+      set(val) {
+        this.$emit('input', val);
+      },
+    },
+  },
+  methods: {
+    saveSale() {
+      if (this.$refs.form.validate()) {
+        this.$emit('save', this.sale);
+        this.handleClose();
+      }
+    },
+    handleClose() {
+      this.isOpen = false;
+      this.$emit('close');
+    },
+  },
+};
+</script>

--- a/src/views/apps/sales/SalesView.vue
+++ b/src/views/apps/sales/SalesView.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+// common components
+import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
+import SalesDetailView from './SalesDetailView.vue';
+// theme breadcrumb
+const page = ref({ title: '매출 정보' });
+
+
+</script>
+
+<template>
+    <BaseBreadcrumb :title="page.title" ></BaseBreadcrumb>
+    <v-card elevation="10">
+        <v-card-text>
+            <SalesDetailView/>
+        </v-card-text>
+    </v-card>
+</template>


### PR DESCRIPTION
## 💬 작업 내용 설명
> 기본 페이지 구현 
카드 형식으로 구현

<br>

<details>
  <summary> 
</summary>

 ![image](https://github.com/user-attachments/assets/e3ebb9d3-ecc7-4ab0-ab4a-1d88c390d4fe)
</details>

<br>

## #️⃣연관된  issue
#37 

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가


<br>

## 📑To Reviewers (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분
