### PR TITLE
[Fix] 새로고침시 로그인 풀림 해결

### DIFF
--- a/src/components/auth/LoginForm.vue
+++ b/src/components/auth/LoginForm.vue
@@ -50,7 +50,7 @@ const loginApi=async()=>{
             alert("로그인을 완료했습니다.");
             const result = res.data.result;
             console.log(result);
-            authStore.setIsLogedIn(true);
+            authStore.setIsLogedIn();
             saveLocalStorage(result);
             router.push("/");  
         }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -22,7 +22,7 @@ router.beforeEach(async (to, from, next) => {
     const auth: any = useAuthStore();
 
     if (to.matched.some((record) => record.meta.requiresAuth)) {
-        if (authRequired && !auth.isLogedIn) {
+        if (authRequired && (localStorage.getItem('isLoggedIn')!=="true")) {
             auth.returnUrl = to.fullPath;
             return next('/auth/login');
         } else next();

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -7,15 +7,15 @@ const baseUrl = `${import.meta.env.VITE_API_URL}/users`;
 export const useAuthStore = defineStore({
     id: 'auth',
     state: () => ({
-        isLogedIn:false,
+      //  isLoggedIn:localStorage.getItem('isLoggedIn')=='true',
         // initialize state from local storage to enable user to stay logged in
         // @ts-ignore
         user: localStorage.getItem('loginUserName'),
         returnUrl: null
     }),
     actions: {
-        setIsLogedIn(status:boolean){
-            this.isLogedIn = status;
+        setIsLogedIn(){
+            localStorage.setItem('isLoggedIn','true');
         },
         
         logout() {
@@ -23,7 +23,7 @@ export const useAuthStore = defineStore({
             localStorage.removeItem('loginUserName');
             localStorage.removeItem('loginUserEmail');
             localStorage.removeItem('accessToken');
-            this.setIsLogedIn(false);
+            localStorage.setItem('isLoggedIn','false');
             router.push({name:"Login"});
         }
     }


### PR DESCRIPTION
## 💬 작업 내용 설명
> localstorage에 로그인 여부 저장해서 새로고침할때 로그인이 풀리는 오류 수정

<br>

<details>
  <summary> 💡 </summary>

- 로그인 전
<img width="383" alt="스크린샷 2024-10-17 오후 12 24 38" src="https://github.com/user-attachments/assets/72a4bd72-6838-4650-89b3-68fcee0ff4d3">

- 로그인 후 

<img width="398" alt="스크린샷 2024-10-17 오후 12 24 59" src="https://github.com/user-attachments/assets/ddecc9cd-779c-4d7c-a0c1-3b911ad170bb">

- 로그아웃 버튼 클릭 후

<img width="436" alt="스크린샷 2024-10-17 오후 12 25 12" src="https://github.com/user-attachments/assets/f1b028ed-0319-4e0d-8daf-9b54a42c9f7f">

<img width="385" alt="스크린샷 2024-10-17 오후 12 25 26" src="https://github.com/user-attachments/assets/454ee7fc-1d29-423a-a5e4-5e05638c613a">

</details>

<br>

## #️⃣연관된  issue
#26 
<br>

## ✅ 체크리스트
- [x] 버그 수정

<br>

## 📑To Reviewers (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분
