### PR TITLE
[Feat/#64] 잠재고객 관련 페이지 디자인 및 API 연결

### DIFF
--- a/src/components/customer/InputForm.vue
+++ b/src/components/customer/InputForm.vue
@@ -81,7 +81,7 @@ const confirmEmail = ref([(v: string) => !!v || '이메일을 입력해주세요
 
 
 const formIsValid = computed(()=>{
-    return customerName.value && email.value && grade.value && phone.value;
+    return customerName.value && email.value && phone.value;
 })
 
 
@@ -130,8 +130,8 @@ const formIsValid = computed(()=>{
         </v-col>
 
         <v-col cols="6">
-            <v-label class="font-weight-medium mb-2">등급</v-label><span class="require">*</span>
-            <v-select v-model="grade" :items="grades" single-line variant="outlined" :rules="confirmGrade"></v-select>
+            <v-label class="font-weight-medium mb-2">등급</v-label>
+            <v-select v-model="grade" :items="grades" single-line variant="outlined"></v-select>
         </v-col>
 
         <v-col cols="6">

--- a/src/components/pcustomer/pCustomerAddCard.vue
+++ b/src/components/pcustomer/pCustomerAddCard.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const props = defineProps({
+    title: String
+});
+</script>
+
+// ===============================|| Ui Parent Card||=============================== //
+<template>
+    <v-card elevation="10" >
+        <v-card-item class="py-4 px-6">
+            <div class="d-sm-flex align-center justify-space-between">
+                <v-card-title class="text-h5">{{ title }}</v-card-title>
+                <!-- <template v-slot:append> -->
+                <slot name="action"></slot>
+                <!-- </template> -->
+            </div>
+        </v-card-item>
+        <v-divider></v-divider>
+        <v-card-text>
+            <slot />
+        </v-card-text>
+    </v-card>
+</template>

--- a/src/components/pcustomer/pCustomerCard.vue
+++ b/src/components/pcustomer/pCustomerCard.vue
@@ -1,0 +1,125 @@
+<script setup>
+import {profileCards} from '@/_mockApis/components/widget/card';
+import { ref ,onMounted, watch,nextTick} from 'vue';
+import user1 from '@/assets/images/profile/user-1.jpg';
+import user2 from '@/assets/images/profile/user-2.jpg';
+import user3 from '@/assets/images/profile/user-3.jpg';
+import user4 from '@/assets/images/profile/user-4.jpg';
+import user5 from '@/assets/images/profile/user-5.jpg';
+import user6 from '@/assets/images/profile/user-6.jpg';
+import user7 from '@/assets/images/profile/user-7.jpg';
+import user8 from '@/assets/images/profile/user-8.jpg';
+import user9 from '@/assets/images/profile/user-9.jpg';
+import user10 from '@/assets/images/profile/user-10.jpg';
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+const props = defineProps({
+    customers:{
+        type:Array,
+        required:true
+    }
+});
+// 프로필 이미지 배열
+const avatarImgs = [user1, user2, user3, user4, user5, user6, user7,user8,user9,user10];
+
+// 각 customer에 랜덤 이미지를 추가하는 함수
+const getRandomImage = () => {
+  const randomIndex = Math.floor(Math.random() * avatarImgs.length);
+  return avatarImgs[randomIndex];
+};
+
+const goToEditPage = (customerId)=>{
+    router.push({name:"CustomerDetail",params:{id:customerId}});
+
+}
+
+</script>
+
+<template>
+       <v-col cols="12">
+        <v-row class="pt-3">
+            <v-col cols="6" md="6" v-for="customer in customers" :key="customer.id" class="column">
+                <v-card elevation="10" class="card text-center" rounded="md" @click="goToEditPage(customer.id)">
+                    <v-card-item class="card_container">
+                        <div class="title_container">
+                            <v-avatar size="60" rounded="xl">
+                                <img :src="getRandomImage()" alt="img" width="60">
+                            </v-avatar>
+                            <div class="name_container">
+                                    <div class="customer_name">{{ customer.name }}</div> 
+                                    <div class="customer_position">( {{ customer.position }} )</div>
+                            </div>
+                        </div>
+
+                        <div class="mt-4 info_container">
+                        
+                            <div>
+                                Company. {{ customer.company }}
+                            </div>
+                        <div>
+                                0건
+                        </div>
+                      </div>
+                    </v-card-item>
+                    <div class="bottom_container">
+                    <div>{{ customer.email }}</div>
+                    <div>{{ customer.phone }} </div>
+                    <div>{{ customer.tel }}</div>
+                </div>
+                </v-card>
+
+            </v-col>
+           
+     </v-row>
+        </v-col>
+</template>
+
+<style lang="scss">
+
+.card_conatiner{
+    display: flex;
+    padding:20px 20px 20px 20px;
+
+}
+.title_container {
+    display: flex;
+    flex-direction: row;
+}
+.info_container {
+    font-size: 14px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    // background-color: rgb(106, 106, 202);
+
+}
+.name_container {
+    margin-left: 4px;
+    display: flex;
+    flex-direction: row;
+    // background-color: yellow;
+    align-items: center;
+}
+
+.customer_name {
+    font-size: 16px;
+    font-weight: 600;
+}
+.customer_position {
+    font-size: 12px;
+}
+
+.bottom_container {
+    padding:10px;
+    background-color: rgb(228, 225, 225);
+    font-size: 12px;
+    display: flex;
+    justify-content: center;
+    color: #1a1818;
+
+    div {
+        padding-right:5px
+    }
+}
+</style>

--- a/src/components/pcustomer/pCustomerCard.vue
+++ b/src/components/pcustomer/pCustomerCard.vue
@@ -1,16 +1,5 @@
 <script setup>
-import {profileCards} from '@/_mockApis/components/widget/card';
 import { ref ,onMounted, watch,nextTick,defineProps} from 'vue';
-import user1 from '@/assets/images/profile/user-1.jpg';
-import user2 from '@/assets/images/profile/user-2.jpg';
-import user3 from '@/assets/images/profile/user-3.jpg';
-import user4 from '@/assets/images/profile/user-4.jpg';
-import user5 from '@/assets/images/profile/user-5.jpg';
-import user6 from '@/assets/images/profile/user-6.jpg';
-import user7 from '@/assets/images/profile/user-7.jpg';
-import user8 from '@/assets/images/profile/user-8.jpg';
-import user9 from '@/assets/images/profile/user-9.jpg';
-import user10 from '@/assets/images/profile/user-10.jpg';
 import { useRouter } from 'vue-router';
 
 const router = useRouter();
@@ -20,8 +9,7 @@ const props = defineProps({
         required:true
     }
 });
-// 프로필 이미지 배열
-const avatarImgs = [user1, user2, user3, user4, user5, user6, user7,user8,user9,user10];
+
 
 // 각 customer에 랜덤 이미지를 추가하는 함수
 const getRandomImage = () => {
@@ -30,7 +18,7 @@ const getRandomImage = () => {
 };
 
 const goToEditPage = (pcustomerId)=>{
-    router.push({name:"CustomerDetail",params:{id:pcustomerId}});
+    router.push({name:"pCustomerDetail",params:{id:pcustomerId}});
 
 }
 

--- a/src/components/pcustomer/pCustomerCard.vue
+++ b/src/components/pcustomer/pCustomerCard.vue
@@ -43,29 +43,24 @@ const goToEditPage = (pcustomerId)=>{
                 <v-card elevation="10" class="card text-center" rounded="md" @click="goToEditPage(pcustomer.id)">
                     <v-card-item class="card_container">
                         <div class="title_container">
-                            <v-avatar size="60" rounded="xl">
-                                <img :src="getRandomImage()" alt="img" width="60">
-                            </v-avatar>
+                        
                             <div class="name_container">
                                     <div class="customer_name">{{ pcustomer.name }}</div> 
-                                    <div class="customer_position">( {{ pcustomer.position }} )</div>
+                                    <div class="customer_position"> <span v-if="pcustomer.company">( <i class="mr-2 mdi text-h5 mdi-domain"></i> {{ pcustomer.company }} )</span></div>
                             </div>
                         </div>
 
                         <div class="mt-4 info_container">
                         
-                            <div>
-                                Company. {{ pcustomer.company }}
-                            </div>
-                        <div>
-                                0건
-                        </div>
+                        <!-- <div>관리자 : <span>{{ pcustomer. }}</span> </div> -->
+                        <div><i class="mr-2 mdi text-h5 mdi-calendar"></i>등록일 : <span v-if="pcustomer.status">{{ pcustomer.registerDate }}</span></div>
+                        <div><i class="mr-2 mdi text-h5 mdi-account-check"></i>접촉상태 : <span v-if="pcustomer.status">{{ pcustomer.status }}</span></div>
                       </div>
                     </v-card-item>
                     <div class="bottom_container">
-                    <div>{{ pcustomer.email }}</div>
-                    <div>{{ pcustomer.phone }} </div>
-                    <div>{{ pcustomer.tel }}</div>
+                    <div><i class="mr-2 mdi text-h5 mdi-email"></i> {{ pcustomer.email }}</div>
+                    <div><i class="mr-2 mdi text-h5 mdi-cellphone-basic"></i>{{ pcustomer.phone }} </div>
+                
                 </div>
                 </v-card>
 

--- a/src/components/pcustomer/pCustomerCard.vue
+++ b/src/components/pcustomer/pCustomerCard.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {profileCards} from '@/_mockApis/components/widget/card';
-import { ref ,onMounted, watch,nextTick} from 'vue';
+import { ref ,onMounted, watch,nextTick,defineProps} from 'vue';
 import user1 from '@/assets/images/profile/user-1.jpg';
 import user2 from '@/assets/images/profile/user-2.jpg';
 import user3 from '@/assets/images/profile/user-3.jpg';
@@ -15,7 +15,7 @@ import { useRouter } from 'vue-router';
 
 const router = useRouter();
 const props = defineProps({
-    customers:{
+    pcustomers:{
         type:Array,
         required:true
     }
@@ -29,8 +29,8 @@ const getRandomImage = () => {
   return avatarImgs[randomIndex];
 };
 
-const goToEditPage = (customerId)=>{
-    router.push({name:"CustomerDetail",params:{id:customerId}});
+const goToEditPage = (pcustomerId)=>{
+    router.push({name:"CustomerDetail",params:{id:pcustomerId}});
 
 }
 
@@ -39,23 +39,23 @@ const goToEditPage = (customerId)=>{
 <template>
        <v-col cols="12">
         <v-row class="pt-3">
-            <v-col cols="6" md="6" v-for="customer in customers" :key="customer.id" class="column">
-                <v-card elevation="10" class="card text-center" rounded="md" @click="goToEditPage(customer.id)">
+            <v-col cols="6" md="6" v-for="pcustomer in pcustomers" :key="pcustomer.id" class="column">
+                <v-card elevation="10" class="card text-center" rounded="md" @click="goToEditPage(pcustomer.id)">
                     <v-card-item class="card_container">
                         <div class="title_container">
                             <v-avatar size="60" rounded="xl">
                                 <img :src="getRandomImage()" alt="img" width="60">
                             </v-avatar>
                             <div class="name_container">
-                                    <div class="customer_name">{{ customer.name }}</div> 
-                                    <div class="customer_position">( {{ customer.position }} )</div>
+                                    <div class="customer_name">{{ pcustomer.name }}</div> 
+                                    <div class="customer_position">( {{ pcustomer.position }} )</div>
                             </div>
                         </div>
 
                         <div class="mt-4 info_container">
                         
                             <div>
-                                Company. {{ customer.company }}
+                                Company. {{ pcustomer.company }}
                             </div>
                         <div>
                                 0건
@@ -63,9 +63,9 @@ const goToEditPage = (customerId)=>{
                       </div>
                     </v-card-item>
                     <div class="bottom_container">
-                    <div>{{ customer.email }}</div>
-                    <div>{{ customer.phone }} </div>
-                    <div>{{ customer.tel }}</div>
+                    <div>{{ pcustomer.email }}</div>
+                    <div>{{ pcustomer.phone }} </div>
+                    <div>{{ pcustomer.tel }}</div>
                 </div>
                 </v-card>
 

--- a/src/components/pcustomer/pCustomerHistoryCard.vue
+++ b/src/components/pcustomer/pCustomerHistoryCard.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+const props = defineProps({
+    title: String
+});
+</script>
+
+// ===============================|| Ui Parent Card||=============================== //
+<template>
+    <v-card elevation="10" >
+        
+        <v-card-text>
+            <slot />
+        </v-card-text>
+    </v-card>
+</template>

--- a/src/components/pcustomer/pCustomerInputForm.vue
+++ b/src/components/pcustomer/pCustomerInputForm.vue
@@ -15,8 +15,14 @@ const position = ref('');
 const phone = ref('');
 const tel = ref('');
 const grade = ref('');
-const keyman = ref(false);
 const token = ref('');
+const fax = ref('');
+const note = ref('');
+const cls = ref('');
+const clsOptions = ref(['자사홈페이지','인터넷검색','지인소개','제품설명회','세미나','전화(인바운드)','채팅','매일','기타']);
+const contact = ref('');
+const contactOptions = ref(['미접촉','접촉시도','접촉중','접촉금지','고객전환','기존고객'])
+const address = ref('');
 
 const router = useRouter();
 
@@ -31,30 +37,22 @@ onMounted(()=>{
     
 })
 
-const registerCustomer = ()=>{
+const registerPCustomer = ()=>{
     registerAPI();
 }
 const registerAPI = async()=>{
     try{
-        const res = await api.post('/customers/add',{
-            name:customerName.value,
-            company:company.value?company.value:null,
-            dept:dept.value? dept.value:null,
-            position:dept.value?  position.value:null,
-            phone:phone.value? phone.value:null,
-            tel: tel.value?  tel.value:null,
-            email:email.value ? email.value:null,
-            grade:grade.value ? grade.value:null,
-            keyman:keyman.value 
+        const response = await api.post('/pcustomers',{
+            
         }
      )
-        if(res.data.code==200){
-            alert(res.data.result);
+        if(response.data.code==200){
+            alert(response.data.result);
             router.push({
-                name: "Customer"
+                name: "pCustomer"
             });
         }else{
-            alert(res.data.result);
+            alert(response.data.result);
         }  
     }catch(err){
         console.log(`[ERROR 몌세지] : ${err}`);
@@ -70,18 +68,25 @@ const confirmName = ref([
 const confirmPhone = ref([
     (s:string) => !!s|| '휴대폰 번호를 입력해주세요'
 ])
-// 등급
-const confirmGrade = ref([
-(v: string) => !!v || '등급을 선택해주세요'
-]);
 
 
 // 이메일
 const confirmEmail = ref([(v: string) => !!v || '이메일을 입력해주세요', (v: string) => /.+@.+\..+/.test(v) || '이메일 형식으로 입력해주세요']);
 
 
+// 접촉구분
+const confirmCls = ref([
+    (v: string) => !!v || '접촉구분을 선택해주세요'
+])
+
+// 접촉구분
+const confirmContact = ref([
+    (v: string) => !!v || '접촉상태를 선택해주세요'
+])
+
+
 const formIsValid = computed(()=>{
-    return customerName.value && email.value && grade.value && phone.value;
+    return customerName.value && email.value && cls.value && contact.value && phone.value;
 })
 
 
@@ -102,12 +107,28 @@ const formIsValid = computed(()=>{
         </v-col>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">부서</v-label>
-            <v-text-field color="primary" v-model="dept" variant="outlined" type="text"  hide-details>
+            <v-text-field color="primary" v-model="dept" variant="outlined" type="text" hide-details>
        
             </v-text-field>
         </v-col>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">직책</v-label>
+            <v-text-field color="primary" v-model="position" variant="outlined" type="text" hide-details>
+            </v-text-field>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">접촉구분</v-label><span class="require">*</span>
+            <v-select v-model="cls" :items="clsOptions" single-line variant="outlined" :rules="confirmCls" ></v-select>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">접촉상태</v-label><span class="require">*</span>
+            <v-select v-model="contact" :items="contactOptions" single-line variant="outlined" :rules="confirmContact"></v-select>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">가망등급</v-label>
             <v-text-field color="primary" v-model="position" variant="outlined" type="text"  hide-details>
             </v-text-field>
         </v-col>
@@ -125,32 +146,32 @@ const formIsValid = computed(()=>{
         </v-col>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">이메일</v-label><span class="require">*</span>
-            <v-text-field color="primary" v-model="email" variant="outlined" type="email" placeholder="john@gmail.com" required :rules="confirmEmail">
-            </v-text-field>
+            <v-text-field color="primary" v-model="email" variant="outlined" type="email" required :rules="confirmEmail"/>
         </v-col>
 
         <v-col cols="6">
-            <v-label class="font-weight-medium mb-2">등급</v-label><span class="require">*</span>
-            <v-select v-model="grade" :items="grades" single-line variant="outlined" :rules="confirmGrade"></v-select>
+            <v-label class="font-weight-medium mb-2">팩스번호</v-label>
+            <v-text-field color="primary" v-model="fax" variant="outlined"/>
         </v-col>
 
+
         <v-col cols="6">
-            <v-label class="font-weight-medium mb-2">키맨여부</v-label>
-            <v-switch color="primary" :model-value="keyman" hide-details></v-switch>
+            <v-label class="font-weight-medium mb-2">주소</v-label>
+            <v-text-field color="primary" v-model="address" variant="outlined" />
         </v-col>
-                 
-        <v-col cols="6">
-            <v-label class="font-weight-medium mb-2">담당자</v-label>
-            <v-text-field disabled color="primary" variant="outlined" type="text"  hide-details v-model="userName">
         
-            </v-text-field>
-        </v-col>
 
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">비고</v-label>
+            <v-textarea v-model="note"  variant="solo"/>
+        </v-col>
     </v-row>
-    <div class="d-flex gap-3 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
-            <v-btn color="info" variant="outlined" to="/sales/contact">목록</v-btn>
-            <v-btn color="primary" variant="outlined" @click="registerCustomer" :disabled="!formIsValid">고객 등록</v-btn>
+
+    <div class="d-flex gap-3 mt-5 mb-7 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
+            <v-btn color="info" variant="outlined" to="/sales/prospect">목록</v-btn>
+            <v-btn color="primary" variant="outlined" @click="registerPCustomer" :disabled="!formIsValid">고객 등록</v-btn>
     </div>   
+
 </template>
 <style scoped>
     .require{

--- a/src/components/pcustomer/pCustomerInputForm.vue
+++ b/src/components/pcustomer/pCustomerInputForm.vue
@@ -6,8 +6,8 @@ import { mask } from 'maska';
 import api from '@/api/axiosinterceptor';
 
 const userName = ref('');
-const grades = ref(['S등급', 'A등급','B등급','C등급','D등급']);
-const customerName = ref('');
+const grades = ref(['S등급', 'A등급','B등급','C등급']);
+const pcName = ref('');
 const email = ref('');
 const company = ref('');
 const dept  = ref('');
@@ -43,7 +43,20 @@ const registerPCustomer = ()=>{
 const registerAPI = async()=>{
     try{
         const response = await api.post('/pcustomers',{
-            
+            name:pcName.value?pcName.value:"",  // 필수
+            company:company.value?company.value:null,
+            dept:dept.value?dept.value:null,
+            position:position.value?position.value:null,
+            cls:cls.value?cls.value:"", // 필수
+            contactStatus:contact.value?contact.value:null, // 필수
+            grade:grade.value?grade.value:null,
+            phone:phone.value?phone.value:"", // 필수
+            tel:tel.value?tel.value:null,
+            email:email.value?email.value:null,
+            fax:fax.value? fax.value:null,
+            addr:address.value?address.value:null,
+            note:note.value?note.value:null,
+                      
         }
      )
         if(response.data.code==200){
@@ -86,7 +99,7 @@ const confirmContact = ref([
 
 
 const formIsValid = computed(()=>{
-    return customerName.value && email.value && cls.value && contact.value && phone.value;
+    return pcName.value && cls.value && contact.value && phone.value;
 })
 
 
@@ -96,7 +109,7 @@ const formIsValid = computed(()=>{
     <v-row>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">고객명</v-label><span class="require">*</span>
-            <v-text-field color="primary" v-model="customerName" variant="outlined" type="text" :rules="confirmName" required>
+            <v-text-field color="primary" v-model="pcName" variant="outlined" type="text" :rules="confirmName" required>
        
             </v-text-field>
         </v-col>
@@ -129,8 +142,7 @@ const formIsValid = computed(()=>{
 
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">가망등급</v-label>
-            <v-text-field color="primary" v-model="position" variant="outlined" type="text"  hide-details>
-            </v-text-field>
+            <v-select v-model="grade" :items="grades" single-line variant="outlined" ></v-select>
         </v-col>
 
         <v-col cols="6">
@@ -145,8 +157,8 @@ const formIsValid = computed(()=>{
             </v-text-field>
         </v-col>
         <v-col cols="6">
-            <v-label class="font-weight-medium mb-2">이메일</v-label><span class="require">*</span>
-            <v-text-field color="primary" v-model="email" variant="outlined" type="email" required :rules="confirmEmail"/>
+            <v-label class="font-weight-medium mb-2">이메일</v-label>
+            <v-text-field color="primary" v-model="email" variant="outlined" type="email"/>
         </v-col>
 
         <v-col cols="6">

--- a/src/components/pcustomer/pCustomerUpdateForm.vue
+++ b/src/components/pcustomer/pCustomerUpdateForm.vue
@@ -29,8 +29,37 @@ onMounted(()=>{
     getCustomerInfoAPI(route.params.id);
 })
 const updatePCustomer = ()=>{
-  //  updatePCustomerAPI();
-  alert('해당 서비스는 오픈 예정입니다.');
+    if(confirm("고객정보를 수정하시겠습니까?")){
+        updatePCustomerAPI(route.params.id);
+    }
+}
+
+const updatePCustomerAPI=async(id: string | string[])=>{
+    try{
+        const res = await api.patch(`/pcustomers/${id}`,{
+            name:pcName.value?pcName.value:"",  // 필수
+            company:company.value?company.value:null,
+            dept:dept.value?dept.value:null,
+            position:position.value?position.value:null,
+            cls:cls.value?cls.value:"", // 필수
+            contactStatus:contact.value?contact.value:null, // 필수
+            grade:grade.value?grade.value:null,
+            phone:phone.value?phone.value:"", // 필수
+            tel:tel.value?tel.value:null,
+            email:email.value?email.value:null,
+            fax:fax.value? fax.value:null,
+            addr:address.value?address.value:null,
+            note:note.value?note.value:null,
+        });
+        console.log(res.data);
+        if(res.data.code==200){
+            alert(res.data.result);
+            getCustomerInfoAPI(route.params.id);
+        }
+    }catch(err){
+        console.log(`[ERROR 몌세지] : ${err}`);
+    }
+
 }
 
 const getCustomerInfoAPI = async(id: string | string[])=>{
@@ -165,7 +194,7 @@ onMounted(()=>{
     </v-row>
     <div class="d-flex gap-3 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
             <v-btn color="info" variant="outlined" to="/sales/prospect">목록</v-btn>
-            <v-btn color="primary" variant="outlined" @click="updateCustomer" :disabled="!formIsValid">고객 정보 수정</v-btn>
+            <v-btn color="primary" variant="outlined" @click="updatePCustomer" :disabled="!formIsValid">고객 정보 수정</v-btn>
     </div>   
 </template>
 <style scoped>

--- a/src/components/pcustomer/pCustomerUpdateForm.vue
+++ b/src/components/pcustomer/pCustomerUpdateForm.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import api from '@/api/axiosinterceptor';
+import { useRouter ,useRoute} from 'vue-router';
+import { mask } from 'maska';  
+
+const userName = ref('');
+const grades = ref(['S등급', 'A등급','B등급','C등급']);
+const pcName = ref('');
+const email = ref('');
+const company = ref('');
+const dept  = ref('');
+const position = ref('');
+const phone = ref('');
+const tel = ref('');
+const grade = ref('');
+const fax = ref('');
+const note = ref('');
+const cls = ref('');
+const clsOptions = ref(['자사홈페이지','인터넷검색','지인소개','제품설명회','세미나','전화(인바운드)','채팅','매일','기타']);
+const contact = ref('');
+const contactOptions = ref(['미접촉','접촉시도','접촉중','접촉금지','고객전환','기존고객'])
+const address = ref('');
+
+const router = useRouter();
+const route = useRoute();
+
+onMounted(()=>{
+    getCustomerInfoAPI(route.params.id);
+})
+const updatePCustomer = ()=>{
+  //  updatePCustomerAPI();
+  alert('해당 서비스는 오픈 예정입니다.');
+}
+
+const getCustomerInfoAPI = async(id: string | string[])=>{
+    try{
+        const res = await api.get(`/pcustomers/${id}`);
+        console.log(res.data.result);
+        if(res.data.code==200){
+            const info = res.data.result;
+            pcName.value = info.name;
+            company.value = info.company;
+            dept.value = info.dept;
+            position.value = info.position;
+            cls.value = info.cls;
+            contact.value = info.status;
+            grade.value = info.grade;
+            phone.value = info.phone;
+            tel.value = info.tel;
+            email.value = info.email;
+            fax.value = info.fax;
+            address.value = info.addr;
+            note.value = info.note;
+        }
+    }catch(err){
+        console.log(`[ERROR 몌세지] : ${err}`);
+    }
+}
+
+const confirmName = ref([
+    (s:string)=> !! s|| '고객명을 입력해주세요'
+]);
+
+// 휴대폰 번호
+const confirmPhone = ref([
+    (s:string) => !!s|| '휴대폰 번호를 입력해주세요'
+])
+
+
+// 접촉구분
+const confirmCls = ref([
+    (v: string) => !!v || '접촉구분을 선택해주세요'
+])
+
+// 접촉구분
+const confirmContact = ref([
+    (v: string) => !!v || '접촉상태를 선택해주세요'
+])
+
+
+const formIsValid = computed(()=>{
+    return pcName.value && cls.value && contact.value && phone.value;
+})
+
+
+onMounted(()=>{
+    userName.value = localStorage.getItem('')||'';
+})
+</script>
+<template>
+    <v-row>
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">고객명</v-label><span class="require">*</span>
+            <v-text-field color="primary" v-model="pcName" variant="outlined" type="text" :rules="confirmName" required>
+       
+            </v-text-field>
+        </v-col>
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">고객사</v-label>
+            <v-text-field color="primary" v-model="company" variant="outlined" type="text"  hide-details>
+            </v-text-field>
+        </v-col>
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">부서</v-label>
+            <v-text-field color="primary" v-model="dept" variant="outlined" type="text" hide-details>
+       
+            </v-text-field>
+        </v-col>
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">직책</v-label>
+            <v-text-field color="primary" v-model="position" variant="outlined" type="text" hide-details>
+            </v-text-field>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">접촉구분</v-label><span class="require">*</span>
+            <v-select v-model="cls" :items="clsOptions" single-line variant="outlined" :rules="confirmCls" ></v-select>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">접촉상태</v-label><span class="require">*</span>
+            <v-select v-model="contact" :items="contactOptions" single-line variant="outlined" :rules="confirmContact"></v-select>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">가망등급</v-label>
+            <v-select v-model="grade" :items="grades" single-line variant="outlined" ></v-select>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">휴대폰번호</v-label><span class="require">*</span>
+            <v-text-field v-maska="'###-####-####'"  color="primary" v-model="phone" variant="outlined" type="text" placeholder="-를 제외하고 입력해주세요" :rules="confirmPhone">
+            </v-text-field>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">유선번호</v-label>
+            <v-text-field v-maska="'##-###-####'"  color="primary" v-model="tel" variant="outlined" type="text" placeholder="-를 제외하고 입력해주세요" hide-details>
+            </v-text-field>
+        </v-col>
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">이메일</v-label>
+            <v-text-field color="primary" v-model="email" variant="outlined" type="email"/>
+        </v-col>
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">팩스번호</v-label>
+            <v-text-field color="primary" v-model="fax" variant="outlined"/>
+        </v-col>
+
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">주소</v-label>
+            <v-text-field color="primary" v-model="address" variant="outlined" />
+        </v-col>
+        
+
+        <v-col cols="6">
+            <v-label class="font-weight-medium mb-2">비고</v-label>
+            <v-textarea v-model="note"  variant="solo"/>
+        </v-col>
+        
+
+    </v-row>
+    <div class="d-flex gap-3 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
+            <v-btn color="info" variant="outlined" to="/sales/prospect">목록</v-btn>
+            <v-btn color="primary" variant="outlined" @click="updateCustomer" :disabled="!formIsValid">고객 정보 수정</v-btn>
+    </div>   
+</template>
+<style scoped>
+    .require{
+        color: red;
+    }
+</style>

--- a/src/layouts/full/vertical-sidebar/sidebarItem.ts
+++ b/src/layouts/full/vertical-sidebar/sidebarItem.ts
@@ -105,7 +105,7 @@ const sidebarItem: menu[] = [
             {
                 title: '잠재고객',
                 icon: CircleDotIcon,
-                to: '/apps/blog/posts'
+                to: '/sales/prospect'
             },
             {
                 title: '제안',

--- a/src/router/MainRoutes.ts
+++ b/src/router/MainRoutes.ts
@@ -516,7 +516,7 @@ const MainRoutes = {
             component: () => import("@/views/apps/customer/CustomerAdd.vue"),
           },
 
-          { // 고객 조회 및 수정
+          { // 고객 상세 조회 및 수정
             name: "CustomerDetail",
             path: "/sales/customer-detail/:id",
             component: () => import("@/views/apps/customer/CustomerDetail.vue"),
@@ -535,6 +535,13 @@ const MainRoutes = {
             component: ()=> import("@/views/apps/pCustomer/pCustomerAdd.vue")
           },
 
+          { // 잠재고객 상세 조회 및 수정
+            name: "pCustomerDetail",
+            path: "/sales/prospect/:id",
+            component: ()=> import("@/views/apps/pCustomer/pCustomerDetail.vue")
+          },
+
+   
           { // 부서
             name: "Department",
             path: "/sales/departments",

--- a/src/router/MainRoutes.ts
+++ b/src/router/MainRoutes.ts
@@ -524,14 +524,14 @@ const MainRoutes = {
           },
 
           { // 잠재고객
-            name: 'pCusomer',
+            name: 'pCustomer',
             path: '/sales/prospect',
             component: ()=> import('@/views/apps/pCustomer/pCustomer.vue')
             },
 
           { // 잠재고객 등록
-            name: "pCustomer",
-            path: "/sales/pcustomer-add",
+            name: "pCustomerAdd",
+            path: "/sales/prospect/add",
             component: ()=> import("@/views/apps/pCustomer/pCustomerAdd.vue")
           },
 

--- a/src/router/MainRoutes.ts
+++ b/src/router/MainRoutes.ts
@@ -1,3 +1,5 @@
+import { Component } from '@fullcalendar/core/preact';
+
 const MainRoutes = {
     path: '/main',
     meta: {
@@ -502,16 +504,16 @@ const MainRoutes = {
 
           // -------- 추가 by kuk329 ------------
 
-        {
-            name: "CustomerAdd",
-            path: "/sales/customer-add",
-            component: () => import("@/views/apps/customer/CustomerAdd.vue"),
-          },
-
-          {
+      
+          { // 고객
             name: "Customer",
             path: "/sales/contact",
             component: () => import("@/views/apps/customer/Customer.vue"),
+          },
+          { // 고객 등록
+            name: "CustomerAdd",
+            path: "/sales/customer-add",
+            component: () => import("@/views/apps/customer/CustomerAdd.vue"),
           },
 
           { // 고객 조회 및 수정
@@ -519,6 +521,18 @@ const MainRoutes = {
             path: "/sales/customer-detail/:id",
             component: () => import("@/views/apps/customer/CustomerDetail.vue"),
             props:true
+          },
+
+          { // 잠재고객
+            name: 'pCusomer',
+            path: '/sales/prospect',
+            component: ()=> import('@/views/apps/pCustomer/pCustomer.vue')
+            },
+
+          { // 잠재고객 등록
+            name: "pCustomer",
+            path: "/sales/pcustomer-add",
+            component: ()=> import("@/views/apps/pCustomer/pCustomerAdd.vue")
           },
 
           { // 부서
@@ -540,6 +554,7 @@ const MainRoutes = {
             component: () => import("@/views/apps/process/Process.vue"),
             props:true
           },
+          
           {
             name: 'Material',
             path: '/icons/material',

--- a/src/views/apps/pCustomer/pCustomer.vue
+++ b/src/views/apps/pCustomer/pCustomer.vue
@@ -8,24 +8,24 @@
         <div class="customer_container">
             <div class="header">
                 <div class="result_count">(검색결과: {{ dataSize }}건)</div>   
-                <v-btn variant="tonal" color="primary" to="/sales/pcustomer-add">잠재고객 추가</v-btn>
+                <v-btn variant="tonal" color="primary" to="/sales/prospect/add">잠재고객 추가</v-btn>
             </div>
          
             <hr  class="divider"></hr>
-                <CustomerCard :customers="customers"/>
+                  <pCustomerCard :pcustomers="pcustomers"/> 
         </div>
     </div>
 </template>
 
 <script setup>
-import CustomerCard from '@/components/customer/CustomerCard.vue';
+import pCustomerCard from '@/components/pcustomer/pCustomerCard.vue';
 import FilterCard from '@/components/customer/FilterCard.vue';
 import axios from 'axios';
 import api from '@/api/axiosinterceptor'
 import { computed, onMounted, ref } from 'vue';
 
-const customers = ref([]);
-const dataSize = computed(()=> customers.value.length);
+const pcustomers = ref([]);
+const dataSize = computed(()=> pcustomers.value.length);
 
 onMounted(()=>{
     fetchCustomers();
@@ -33,17 +33,16 @@ onMounted(()=>{
 
 const fetchCustomers=async()=>{
     try{
-       // const res = await axios.get('http://localhost:8080/api/customers');
-        const res = await api.get('/customers');
+        const res = await api.get('/pcustomers');
+        console.log(res);
         if(res.data.code==200) {
             console.log(res.data.result);
-            customers.value = res.data.result;
+            pcustomers.value = res.data.result;
         }
     }catch(err){
         console.log(`[ERROR 몌세지] : ${err}`);
     }
     
-
 }
 
 </script>

--- a/src/views/apps/pCustomer/pCustomer.vue
+++ b/src/views/apps/pCustomer/pCustomer.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="container">
+        
+        <div class="filter_container">
+            <FilterCard/> 
+        </div>
+    
+        <div class="customer_container">
+            <div class="header">
+                <div class="result_count">(검색결과: {{ dataSize }}건)</div>   
+                <v-btn variant="tonal" color="primary" to="/sales/pcustomer-add">잠재고객 추가</v-btn>
+            </div>
+         
+            <hr  class="divider"></hr>
+                <CustomerCard :customers="customers"/>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import CustomerCard from '@/components/customer/CustomerCard.vue';
+import FilterCard from '@/components/customer/FilterCard.vue';
+import axios from 'axios';
+import api from '@/api/axiosinterceptor'
+import { computed, onMounted, ref } from 'vue';
+
+const customers = ref([]);
+const dataSize = computed(()=> customers.value.length);
+
+onMounted(()=>{
+    fetchCustomers();
+})
+
+const fetchCustomers=async()=>{
+    try{
+       // const res = await axios.get('http://localhost:8080/api/customers');
+        const res = await api.get('/customers');
+        if(res.data.code==200) {
+            console.log(res.data.result);
+            customers.value = res.data.result;
+        }
+    }catch(err){
+        console.log(`[ERROR 몌세지] : ${err}`);
+    }
+    
+
+}
+
+</script>
+
+<style lang="scss" scoped>
+.header {
+    font-size: 12px;
+    margin:15px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.container {
+   
+    display: flex;
+    flex-direction: row;
+//   background-color: yellow;
+}
+
+.filter_container {
+    background-color: white;
+    margin-right: 30px;
+    width: 25%;
+}
+
+.customer_container {
+    background-color: white;
+    width: 80%;
+}
+.divider{
+    border-color:rgb(0, 110, 255);
+    margin-left:15px;
+    margin-right: 15px;
+}
+
+</style>

--- a/src/views/apps/pCustomer/pCustomerAdd.vue
+++ b/src/views/apps/pCustomer/pCustomerAdd.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+// common components
+
+//Components
+import pCustomerAddCard from '@/components/pcustomer/pCustomerAddCard.vue';
+import pCustomerInputForm from '@/components/pcustomer/pCustomerInputForm.vue';
+import pCustomerHistoryCard from '@/components/pcustomer/pCustomerHistoryCard.vue';
+
+/*tab*/
+const tab = ref(null);
+
+const page = ref({ title: '잠재고객 등록' });
+
+const addHistory = ()=>{
+     alert("서비스 오픈예정");
+}
+</script>
+
+<template>
+     <v-row class="mb-3">
+          <pCustomerAddCard :title="page.title">
+               <pCustomerInputForm />
+          </pCustomerAddCard>
+
+     </v-row>
+     <v-row>
+          <pCustomerHistoryCard>
+               <div class="history_container">
+                    <div>이력 (1)</div>
+                    <div class="history_plus" @click="addHistory"><v-icon color="error" icon="$plus" size="x-large" /></div>
+               </div>
+               <hr class="divider">
+               </hr>
+
+               <v-col cols="12">
+                   <div>
+                    <div>2024.10.23 (방문) - 삼다수</div>
+                    <hr/>
+                    <div>오후 2시 방문 예정</div>
+                   </div>
+               </v-col>
+               <v-col cols="12">
+                   <div>
+                    <div>2024.10.23 (메일) - 삼다수</div>
+                    <hr/>
+                    <div>상담 날짜 약속을 위한 메일</div>
+                   </div>
+               </v-col>
+          </pCustomerHistoryCard>
+
+     </v-row>
+</template>
+<style lang="scss" scoped>
+.history_container {
+     display: flex;
+     justify-content: space-between;
+     font-size: 14px;
+}
+
+.divider {
+     border-color: rgb(0, 110, 255);
+}
+
+.history_plus {
+     cursor: pointer;
+}
+</style>

--- a/src/views/apps/pCustomer/pCustomerDetail.vue
+++ b/src/views/apps/pCustomer/pCustomerDetail.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+// common components
+
+//Components
+import CustomerAddCard from '@/components/customer/CustomerAddCard.vue';
+import pCustomerHistoryCard from '@/components/pcustomer/pCustomerHistoryCard.vue';
+import pCustomerUpdateForm from '@/components/pcustomer/pCustomerUpdateForm.vue';
+
+/*tab*/
+const tab = ref(null);
+
+const page = ref({ title: '고객 정보' });
+const addHistory = ()=>{
+     
+}
+</script>
+
+<template>
+   <v-row class="mb-3">
+        <CustomerAddCard :title=page.title>
+             <pCustomerUpdateForm/>
+        </CustomerAddCard>        
+                            
+   </v-row>           
+   <v-row>
+          <pCustomerHistoryCard>
+               <div class="history_container">
+                    <div>이력 (1)</div>
+                    <div class="history_plus" @click="addHistory"><v-icon color="error" icon="$plus" size="x-large" /></div>
+               </div>
+               <hr class="divider">
+               </hr>
+
+               <v-col cols="12">
+                   <div>
+                    <div>2024.10.23 (방문) - 삼다수</div>
+                    <hr/>
+                    <div>오후 2시 방문 예정</div>
+                   </div>
+               </v-col>
+               <v-col cols="12">
+                   <div>
+                    <div>2024.10.23 (메일) - 삼다수</div>
+                    <hr/>
+                    <div>상담 날짜 약속을 위한 메일</div>
+                   </div>
+               </v-col>
+          </pCustomerHistoryCard>
+
+     </v-row>
+</template>
+<style lang="scss" scoped>
+.history_container {
+     display: flex;
+     justify-content: space-between;
+     font-size: 14px;
+}
+
+.divider {
+     border-color: rgb(0, 110, 255);
+}
+
+.history_plus {
+     cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## 💬 작업 내용 설명
> 잠재고객 관련 페이지 디자인 및 API 연결

<br>

<details>
  <summary> 목록 </summary>

<img width="1189" alt="스크린샷 2024-10-19 오후 7 58 49" src="https://github.com/user-attachments/assets/529a727e-4e46-4a76-9779-5f77d1858aca">

</details>

<details>
  <summary> 조회 </summary>

<img width="1351" alt="스크린샷 2024-10-19 오후 7 59 22" src="https://github.com/user-attachments/assets/697df005-92fa-4997-a37d-e833e8f59f9c">


</details>

<details>
  <summary> 추가 </summary>

<img width="684" alt="스크린샷 2024-10-19 오후 7 59 53" src="https://github.com/user-attachments/assets/fe39314b-5e11-4ad5-af9c-9a9598e8dfcb">


</details>

<br>

## #️⃣연관된  issue
#64

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

<br>

## 📑To Reviewers (선택)

- 🫨