### PR TITLE
[Feat/#64] 접촉 이력 관련 화면 디자인 & API 연결

### DIFF
--- a/src/components/pcustomer/ConfirmDialogs.vue
+++ b/src/components/pcustomer/ConfirmDialogs.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  dialog: Boolean,
+});
+const emit = defineEmits(['agree', 'disagree', 'update:dialog']);
+
+const closeDialog = () => {
+  emit('disagree');
+  emit('update:dialog', false);
+};
+const agreeDialog = () => {
+  emit('agree');
+  emit('update:dialog', false);
+};
+</script>
+
+<template>
+  <div class="text-center">
+    <v-dialog v-bind:model-value="dialog" @update:model-value="(val) => emit('update:dialog', val)" persistent max-width="400px">
+      <v-card class="pa-6">
+        <v-card-title class="text-h4 font-weight-bold d-flex align-center">
+          <v-icon size="40" class="mr-2" color="error">mdi-alert-circle</v-icon>
+          삭제 경고
+        </v-card-title>
+        <v-card-text class="text-h5">정말 삭제하시겠습니까?</v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="green darken-1" variant="text" @click="closeDialog" flat>Disagree</v-btn>
+          <v-btn color="error" variant="text" @click="agreeDialog" flat>Agree</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<style scoped>
+.dialog-mw {
+  max-width: 400px; /* 가로폭 제한 */
+}
+</style>

--- a/src/components/pcustomer/HistoryModal.vue
+++ b/src/components/pcustomer/HistoryModal.vue
@@ -1,17 +1,70 @@
 <script setup lang="ts">
-import { ref,defineProps,defineEmits } from "vue";
+import api from "@/api/axiosinterceptor";
+import { ref,defineProps,defineEmits, computed } from "vue";
+import { useRoute } from "vue-router";
 
+const route = useRoute();
 const props = defineProps({
   dialog:{
     type:Boolean,
     required:true
   }
 });
-const emit  = defineEmits(["update:dialog","close","sasve"]);
+const emit  = defineEmits(["update:dialog","close","save"]);
 
 const date = ref();
 const contact = ref();
 const content = ref();
+
+const confirmDate = ref([
+    (s:string)=> !! s|| '날짜를 선택해주세요'
+]);
+
+const confirmContact = ref([
+    (s:string)=> !! s|| '접촉구분을 선택해주세요'
+]);
+
+const formIsValid = computed(()=>{
+    return date.value && contact.value;
+})
+
+const saveHistory = ()=>{
+ 
+  if(formIsValid){
+    saveHistoryAPI(route.params.id);
+    
+  }else{
+    alert("필수 정보를 입력해주세요");
+  }
+  
+}
+const resetForm =()=>{
+  date.value = '';
+  contact.value = '';
+  content.value = '';
+}
+
+const saveHistoryAPI=async(id: string | string[])=>{
+  try{
+    const response = await api.post(`/pcustomers/${id}/history`,{
+      contactDate:date.value?date.value:null,
+      cls:contact.value?contact.value:null,
+      content:content.value?content.value:null,
+    });
+    console.log(response);
+    if(response.data.code == 200){
+        alert(response.data.result);
+        resetForm();
+        emit('save'); 
+    }else{
+      alert(response.data.message);
+    }
+
+  }catch(err){
+    console.log(`[ERROR 몌세지] : ${err}`);
+  }
+}
+
 </script>
 
 <template>
@@ -27,18 +80,17 @@ const content = ref();
             <v-row>
               <v-col cols="12" sm="6" >
                 <v-label class="font-weight-medium">접촉일</v-label>
-                <v-text-field color="primary" variant="outlined" v-model="date" type="date" ></v-text-field>
+                <v-text-field color="primary" variant="outlined" v-model="date" type="date" :rules="confirmDate"></v-text-field>
               </v-col>
        
           <v-col cols="12" sm="6">     
             <v-label class="font-weight-medium">접촉구분</v-label>
-            <v-select v-model="contact" :items="['전화','메일','방문','온라인 미팅','채널톡','기타']" single-line variant="outlined"></v-select>
+            <v-select v-model="contact" :items="['전화','메일','방문','온라인 미팅','채널톡','기타']" single-line variant="outlined" :rules="confirmContact"></v-select>
           </v-col>
 
           <v-col>
             <v-label class="font-weight-medium mb-2">접촉내용</v-label>
-            <v-text-field  color="primary" v-model="content" variant="outlined" type="text">
-            </v-text-field>
+            <v-text-field  color="primary" v-model="content" variant="outlined" type="text"/>
           </v-col>
             </v-row>
         </v-card-text>
@@ -48,7 +100,7 @@ const content = ref();
           <v-btn color="error" variant="text" @click="emit('close')" flat>
             닫기
           </v-btn>
-          <v-btn color="success" variant="text" @click="emit('sasve')" flat>
+          <v-btn color="success" variant="text" @click="saveHistory" flat>
             저장
           </v-btn>
         </v-card-actions>

--- a/src/components/pcustomer/HistoryModal.vue
+++ b/src/components/pcustomer/HistoryModal.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref,defineProps,defineEmits } from "vue";
+
+const props = defineProps({
+  dialog:{
+    type:Boolean,
+    required:true
+  }
+});
+const emit  = defineEmits(["update:dialog","close","sasve"]);
+
+const date = ref();
+const contact = ref();
+const content = ref();
+</script>
+
+<template>
+  <div class="text-center">
+    <v-dialog v-model="props.dialog" persistent class="dialog-mw" @update:modelValue="emit('update:dialog', $event)" max-height="360px">
+      <v-card style="height: 400px" class="overflow-auto">
+        <v-container class="pb-0">
+        <v-card-title class="pa-5">
+          <span class="text-h5">접촉이력 등록</span>
+        </v-card-title>
+        <v-card-text>
+          
+            <v-row>
+              <v-col cols="12" sm="6" >
+                <v-label class="font-weight-medium">접촉일</v-label>
+                <v-text-field color="primary" variant="outlined" v-model="date" type="date" ></v-text-field>
+              </v-col>
+       
+          <v-col cols="12" sm="6">     
+            <v-label class="font-weight-medium">접촉구분</v-label>
+            <v-select v-model="contact" :items="['전화','메일','방문','온라인 미팅','채널톡','기타']" single-line variant="outlined"></v-select>
+          </v-col>
+
+          <v-col>
+            <v-label class="font-weight-medium mb-2">접촉내용</v-label>
+            <v-text-field  color="primary" v-model="content" variant="outlined" type="text">
+            </v-text-field>
+          </v-col>
+            </v-row>
+        </v-card-text>
+        
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="error" variant="text" @click="emit('close')" flat>
+            닫기
+          </v-btn>
+          <v-btn color="success" variant="text" @click="emit('sasve')" flat>
+            저장
+          </v-btn>
+        </v-card-actions>
+      </v-container>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>

--- a/src/components/pcustomer/HistoryModal.vue
+++ b/src/components/pcustomer/HistoryModal.vue
@@ -30,7 +30,7 @@ const formIsValid = computed(()=>{
 
 const saveHistory = ()=>{
  
-  if(formIsValid){
+  if(formIsValid.value){
     saveHistoryAPI(route.params.id);
     
   }else{

--- a/src/components/pcustomer/pCustomerUpdateForm.vue
+++ b/src/components/pcustomer/pCustomerUpdateForm.vue
@@ -36,7 +36,7 @@ const updatePCustomer = ()=>{
 
 const updatePCustomerAPI=async(id: string | string[])=>{
     try{
-        const res = await api.patch(`/pcustomers/${id}`,{
+        const response = await api.patch(`/pcustomers/${id}`,{
             name:pcName.value?pcName.value:"",  // 필수
             company:company.value?company.value:null,
             dept:dept.value?dept.value:null,
@@ -51,9 +51,9 @@ const updatePCustomerAPI=async(id: string | string[])=>{
             addr:address.value?address.value:null,
             note:note.value?note.value:null,
         });
-        console.log(res.data);
-        if(res.data.code==200){
-            alert(res.data.result);
+        console.log(response.data);
+        if(response.data.result.code ==200){
+            alert(response.data.result);
             getCustomerInfoAPI(route.params.id);
         }
     }catch(err){

--- a/src/views/apps/pCustomer/pCustomerAdd.vue
+++ b/src/views/apps/pCustomer/pCustomerAdd.vue
@@ -24,7 +24,7 @@ const addHistory = ()=>{
           </pCustomerAddCard>
 
      </v-row>
-     <v-row>
+     <!-- <v-row>
           <pCustomerHistoryCard>
                <div class="history_container">
                     <div>이력 (1)</div>
@@ -49,7 +49,7 @@ const addHistory = ()=>{
                </v-col>
           </pCustomerHistoryCard>
 
-     </v-row>
+     </v-row> -->
 </template>
 <style lang="scss" scoped>
 .history_container {

--- a/src/views/apps/pCustomer/pCustomerDetail.vue
+++ b/src/views/apps/pCustomer/pCustomerDetail.vue
@@ -6,13 +6,24 @@ import { ref } from 'vue';
 import CustomerAddCard from '@/components/customer/CustomerAddCard.vue';
 import pCustomerHistoryCard from '@/components/pcustomer/pCustomerHistoryCard.vue';
 import pCustomerUpdateForm from '@/components/pcustomer/pCustomerUpdateForm.vue';
+import HistoryModal from '@/components/pcustomer/HistoryModal.vue';
 
 /*tab*/
 const tab = ref(null);
-
 const page = ref({ title: '고객 정보' });
-const addHistory = ()=>{
-     
+const dialog=ref(false);
+
+const openHistoryModal = ()=>{
+     console.log('click')
+     dialog.value = true // 모달 열기
+
+}
+
+const closeHistoryModal = ()=>{
+     dialog.value = false; // 모달 닫기
+}
+const saveHistory = ()=>{
+     // api 로 데이터 저장. -> 얘는 하위 컴포넌트에서?
 }
 </script>
 
@@ -22,12 +33,14 @@ const addHistory = ()=>{
              <pCustomerUpdateForm/>
         </CustomerAddCard>        
                             
-   </v-row>           
+   </v-row>
+
+   <!-- todo : Refactoring : 컴포넌트로 분리 -->           
    <v-row>
           <pCustomerHistoryCard>
                <div class="history_container">
-                    <div>이력 (1)</div>
-                    <div class="history_plus" @click="addHistory"><v-icon color="error" icon="$plus" size="x-large" /></div>
+                    <div>접촉 이력 (1)</div>
+                    <div class="history_plus" @click="openHistoryModal"><v-icon color="error" icon="$plus" size="x-large" /></div>
                </div>
                <hr class="divider">
                </hr>
@@ -47,7 +60,7 @@ const addHistory = ()=>{
                    </div>
                </v-col>
           </pCustomerHistoryCard>
-
+          <HistoryModal :dialog="dialog" @update:dialog="dialog=$event" @close="closeHistoryModal" @save="saveHistory"/>
      </v-row>
 </template>
 <style lang="scss" scoped>

--- a/src/views/apps/pCustomer/pCustomerDetail.vue
+++ b/src/views/apps/pCustomer/pCustomerDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref , computed} from 'vue';
 // common components
 
 //Components
@@ -7,11 +7,27 @@ import CustomerAddCard from '@/components/customer/CustomerAddCard.vue';
 import pCustomerHistoryCard from '@/components/pcustomer/pCustomerHistoryCard.vue';
 import pCustomerUpdateForm from '@/components/pcustomer/pCustomerUpdateForm.vue';
 import HistoryModal from '@/components/pcustomer/HistoryModal.vue';
+import { useRoute } from 'vue-router';
+import api from '@/api/axiosinterceptor';
 
-/*tab*/
+
+interface History {
+  id: number;
+  contactDate: string;
+  cls: string;
+  content: string;
+  userName:string;
+}
+
+onMounted(()=>{
+     getHistorysAPI(route.params.id);
+});
+const dataSize = computed(()=> historys.value.length);
+const route = useRoute();
 const tab = ref(null);
 const page = ref({ title: '고객 정보' });
 const dialog=ref(false);
+const historys = ref<History[]>([]);
 
 const openHistoryModal = ()=>{
      dialog.value = true // 접촉이력 창 열기
@@ -21,11 +37,26 @@ const closeHistoryModal = ()=>{
      dialog.value = false; // 접촉이력 창 닫기
 }
 const saveHistory = ()=>{
-     // api 로 데이터 저장
-     console.log('부모 컴포넌트 호출함');
      // 모달창 닫음
      dialog.value = false;
+     getHistorysAPI(route.params.id);
 }
+
+const getHistorysAPI=async(id: string | string[])=>{
+     try{
+          const response = await api.get(`/pcustomers/${id}/history`);
+
+          console.log(response);
+          if(response.data.code != 200){
+               alert(response.data.message);
+          }else{
+               historys.value = response.data.result;
+          }
+     }catch(err){
+          console.log(`[ERROR 몌세지] : ${err}`);
+     }
+}
+
 </script>
 
 <template>
@@ -40,24 +71,17 @@ const saveHistory = ()=>{
    <v-row>
           <pCustomerHistoryCard>
                <div class="history_container">
-                    <div>접촉 이력 (1)</div>
+                    <div>접촉 이력 ({{ dataSize }})</div>
                     <div class="history_plus" @click="openHistoryModal"><v-icon color="error" icon="$plus" size="x-large" /></div>
                </div>
                <hr class="divider">
                </hr>
 
-               <v-col cols="12">
+               <v-col cols="12" v-for="history in historys" :key="history.id">
                    <div>
-                    <div>2024.10.23 (방문) - 삼다수</div>
+                    <div>{{ history.contactDate }} ({{ history.cls }}) - {{ history.userName }}</div>
                     <hr/>
-                    <div>오후 2시 방문 예정</div>
-                   </div>
-               </v-col>
-               <v-col cols="12">
-                   <div>
-                    <div>2024.10.23 (메일) - 삼다수</div>
-                    <hr/>
-                    <div>상담 날짜 약속을 위한 메일</div>
+                    <div>{{ history.content }}</div>
                    </div>
                </v-col>
           </pCustomerHistoryCard>

--- a/src/views/apps/pCustomer/pCustomerDetail.vue
+++ b/src/views/apps/pCustomer/pCustomerDetail.vue
@@ -14,16 +14,17 @@ const page = ref({ title: '고객 정보' });
 const dialog=ref(false);
 
 const openHistoryModal = ()=>{
-     console.log('click')
-     dialog.value = true // 모달 열기
-
+     dialog.value = true // 접촉이력 창 열기
 }
 
 const closeHistoryModal = ()=>{
-     dialog.value = false; // 모달 닫기
+     dialog.value = false; // 접촉이력 창 닫기
 }
 const saveHistory = ()=>{
-     // api 로 데이터 저장. -> 얘는 하위 컴포넌트에서?
+     // api 로 데이터 저장
+     console.log('부모 컴포넌트 호출함');
+     // 모달창 닫음
+     dialog.value = false;
 }
 </script>
 


### PR DESCRIPTION
## 💬 작업 내용 설명
> 잠재고객에 대한 접촉이력 정보를 등록, 조회 하는 화면 디자인
관련 API 연결

<br>

<details>
  <summary> 조회 </summary>
<img width="1277" alt="스크린샷 2024-10-20 오후 11 38 07" src="https://github.com/user-attachments/assets/6e5c2aca-8a46-4f83-b3c2-4a3e6517afc1">

</details>

<details>
  <summary> 등록 </summary>
<img width="1110" alt="스크린샷 2024-10-20 오후 11 39 07" src="https://github.com/user-attachments/assets/96671014-c9ed-4b43-8363-d74fc8291333">


</details>

<br>

## #️⃣연관된  issue
#64

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정

<br>

## 📑To Reviewers (선택)

- 잠재고객에 대한 접촉 이력 정보를 작성할 수 있는데, 잠재고객 생성후 추가 가능 
-  작성자는 현재 로그인한 유저(영업사원) 정보가 자동으로 들어감
- 접촉이력은 등록, 조회만 가능
