### PR TITLE
[Feat/#87] Plan 분류에 도메인 연결 기능 추가

### DIFF
--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -143,7 +143,7 @@ export default {
 			timeOptions: this.generateTimeOptions(), 
 			planClsOptions: ['개인', '전사', '제안', '견적', '매출', '계약'],
 			planCls: '',
-			personalYn: this.plan.personalYn === 'Y',
+			isPersonal: this.plan.personalYn === 'Y',
 			planDetails: {
 				title: '',
 				note: '',
@@ -159,7 +159,7 @@ export default {
 		};
 	},
 	watch: {
-		isPrivate(newValue) {
+		isPersonal(newValue) {
 			this.plan.personalYn = newValue ? 'Y' : 'N';
 		},
 		'plan.personalYn': {

--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -82,6 +82,7 @@
 			<v-card>
 				<v-card-title class="headline">{{ dynamicCardTitle}}</v-card-title>
 				<v-card-text>
+					<perfect-scrollbar style="max-height: 300px">
 					<v-list>
 						<v-list-item
 							v-for="(item, index) in domainList"
@@ -96,6 +97,7 @@
 							</v-list-item-content>
 						</v-list-item>
 					</v-list>
+				</perfect-scrollbar>
 				</v-card-text>
 				<v-card-actions>
 					<v-spacer></v-spacer>

--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -20,9 +20,22 @@
 								v-model="plan.planCls"
 								:items="planClsOptions"
 								label="분류*" outlined
+								@update:model-value ="fetchDomainDetails"
 								:rules="[v => !!v || '분류를 선택하세요.']"
 								required
 							></v-select>
+						</v-col>
+						<v-col cols="12" v-if="plan.planCls && !['개인', '전사'].includes(this.plan.planCls)">
+							<v-text-field 
+								v-model="planDetails.title" 
+								:label="dynamicTitleLabel" 
+								readonly
+							></v-text-field>
+							<v-text-field 
+								v-model="planDetails.note" 
+								:label="dynamicNoteLabel" 
+								readonly
+							></v-text-field>
 						</v-col>
 						<v-col cols="12">
 							<v-text-field v-model="plan.planDate" label="일자*" type="date" 
@@ -49,7 +62,7 @@
 								></v-select>
 							</v-col>
 						<v-col cols="12">
-							<v-switch color="primary" v-model="plan.privateYn" label="나만보기 여부"></v-switch>
+							<v-switch color="primary" v-model="isPersonal" label="나만보기 여부"></v-switch>
 						</v-col>
 						<v-col cols="12">
 							<v-text-field v-model="plan.content" label="내용"></v-text-field>
@@ -64,11 +77,39 @@
 				<v-btn color="success" variant="text" @click="submitPlan" flat>Save</v-btn>
 			</v-card-actions>
 		</v-card>
+		
+		<v-dialog v-model="isSelected" max-width="450px">
+			<v-card>
+				<v-card-title class="headline">{{ dynamicCardTitle}}</v-card-title>
+				<v-card-text>
+					<v-list>
+						<v-list-item
+							v-for="(item, index) in domainList"
+							:key="index"
+							@click="selectDomain(item)"
+							class="list-item-spacing"
+						>
+							<v-list-item-content>
+								
+								<v-list-item-title class="list-item-title"><v-icon small class="mr-2">mdi-check</v-icon>{{ item[titleField] }}</v-list-item-title>
+								<v-list-item-subtitle class="note-text">{{ item[noteField] }}</v-list-item-subtitle>
+							</v-list-item-content>
+						</v-list-item>
+					</v-list>
+				</v-card-text>
+				<v-card-actions>
+					<v-spacer></v-spacer>
+					<v-btn text @click="isSelected = false">닫기</v-btn>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
 	</v-dialog>
 </template>
 
 <script>
 import '@/views/apps/calendar/calendar.css';
+import api from '@/api/axiosinterceptor';
+import {planClsMapping, categoryColors} from '@/utils/PlanMappings'
 
 export default {
 	props: {
@@ -77,12 +118,36 @@ export default {
 		statusOptions: Array,
 		planClsOptions: Array
 	},
+	computed: {
+		dynamicCardTitle() {
+			if (!this.plan.planCls) return '';
+			return `${this.plan.planCls} 목록`;
+		},
+		dynamicTitleLabel() {
+			if (!this.plan.planCls) return '관련 도메인';
+			return `관련 ${this.plan.planCls} `;
+		},
+		dynamicNoteLabel() {
+			if (!this.plan.planCls) return '내용';
+			return `${this.plan.planCls} 내용`;
+		},
+	},
+
 	data() {
 		return {
 			showAlert: false,
-      timeOptions: this.generateTimeOptions(), 
-      planClsOptions: ['개인', '전사', '제안', '견적', '매출', '계약'],
-      planCls: '',
+			isSelected: false,
+			domainList: [],
+			titleField: 'name',
+			noteField: 'note',
+			timeOptions: this.generateTimeOptions(), 
+			planClsOptions: ['개인', '전사', '제안', '견적', '매출', '계약'],
+			planCls: '',
+			personalYn: this.plan.personalYn === 'Y',
+			planDetails: {
+				title: '',
+				note: '',
+			},
 			categoryColors: {
 				personal_plan: { color: '#f7eaa4', label: '개인 일정' },
 				company_plan: { color: '#e5eaac', label: '전사 일정' },
@@ -93,22 +158,89 @@ export default {
 			}
 		};
 	},
+	watch: {
+		isPrivate(newValue) {
+			this.plan.personalYn = newValue ? 'Y' : 'N';
+		},
+		'plan.personalYn': {
+			handler(newValue) {
+				this.isPersonal = newValue === 'Y';
+			},
+			immediate: true,
+		},
+	},
 	methods: {
-    generateTimeOptions() {
-      const options = [];
-      for (let hour = 0; hour < 24; hour++) {
-        for (let minute = 0; minute < 60; minute += 30) {
-          const paddedHour = hour.toString().padStart(2, '0');
-          const paddedMinute = minute.toString().padStart(2, '0');
-          options.push(`${paddedHour}:${paddedMinute}`);
-        }
-      }
-      return options;
-    },
-    submitPlan() {
+		async fetchDomainDetails() {
+		const planCls = this.plan.planCls;
+		console.log(planCls, 'planCls');
+			let apiUrl = '';
+			let titleField = '';
+			let noteField = '';
+			switch (planCls) {
+				case '매출':
+					apiUrl = `sales`;
+					this.titleField = 'busiTypeDetail';
+					noteField = 'note';
+					break;
+				case '제안':
+					apiUrl = `proposals`;
+					this.titleField = 'name';
+					noteField = 'cont';
+					break;
+				case '견적':
+					apiUrl = `estimates`;
+					this.titleField = 'name';
+					noteField = 'note';
+					break;
+				case '계약':
+					apiUrl = `contract`;
+					this.titleField = 'name';
+					noteField = 'note';
+					break;
+				default:
+					this.domainList = [];
+					return;
+			}
+
+			try {
+				const response = await api.get(apiUrl);
+				console.log(response.data)
+
+				if (planCls === '제안') {
+					this.domainList = response.data;
+				} else {
+					this.domainList = response.data.result;
+				}
+				console.log('this.domainList',this.domainList)
+				this.isSelected = true;
+			} catch (error) {
+				console.error(error);
+				this.domainList = [];
+			}
+		},
+		selectDomain(item) {
+			this.planDetails = {
+				title: item[this.titleField] || '',
+				note: item[this.noteField] || '',
+			};	
+			this.isSelected = false;
+			this.domainList = [];
+		},
+		generateTimeOptions() {
+			const options = [];
+			for (let hour = 0; hour < 24; hour++) {
+				for (let minute = 0; minute < 60; minute += 30) {
+					const paddedHour = hour.toString().padStart(2, '0');
+					const paddedMinute = minute.toString().padStart(2, '0');
+					options.push(`${paddedHour}:${paddedMinute}`);
+				}
+			}
+			return options;
+		},
+		submitPlan() {
 			if (!this.plan.title || !this.plan.planCls || !this.plan.planDate || !this.plan.startTime || !this.plan.endTime) {
 				this.showAlert = true;
-        this.alertMessage = '필수 필드를 입력해주세요'
+				this.alertMessage = '필수 필드를 입력해주세요'
 				setTimeout(() => {
 					this.showAlert = false;
 				}, 2000);
@@ -116,22 +248,6 @@ export default {
 			}
 			this.showAlert = false;  
 			
-      const planClsMapping = {
-        '개인': 'PERSONAL',
-        '전사': 'COMPANY',
-        '제안': 'PROPOSAL',
-        '견적': 'ESTIMATE',
-				'매출': 'SALES',
-        '계약': 'CONTRACT'
-      };
-			const categoryColors = {
-				'PERSONAL': '#f7eaa4',
-				'COMPANY': '#dde2a9',
-				'PROPOSAL': '#9ed7a9',
-				'ESTIMATE': '#ccd5db',
-				'SALES': '#a4bbe1',
-				'CONTRACT': '#a4cbe8'
-			};
 
 			if (!this.plan.planCls || !planClsMapping[this.plan.planCls]) {
 				return;
@@ -142,11 +258,11 @@ export default {
 			const categoryColor = categoryColors[this.plan.planCls];
 			this.plan.backgroundColor = categoryColor;
 
-      this.$emit('show-alert', {
-        message: '저장이 완료되었습니다.',
-        type: 'success',
-      });
-      this.$emit('add', this.plan);
+			this.$emit('show-alert', {
+				message: '저장이 완료되었습니다.',
+				type: 'success',
+			});
+			this.$emit('add', this.plan);
 			this.closeModal();
 			},
 
@@ -167,4 +283,24 @@ export default {
 	z-index: 3000;
 	width: 60%;
 }
+.headline {
+	padding-top: 20px;
+	font-weight: bold;
+}
+
+.list-item-spacing {
+	margin-bottom: 12px;
+}
+
+.list-item-title {
+	font-size: 1em;
+	font-weight: 500;
+}
+
+.note-text {
+	font-size: 0.9rem;
+	margin-left: 37px;
+	color: #464646;
+}
+
 </style>

--- a/src/utils/PlanMappings.js
+++ b/src/utils/PlanMappings.js
@@ -1,0 +1,26 @@
+export const planClsMapping = {
+  '개인': 'PERSONAL',
+  '전사': 'COMPANY',
+  '제안': 'PROPOSAL',
+  '견적': 'ESTIMATE',
+  '매출': 'SALES',
+  '계약': 'CONTRACT'
+};
+
+export const reversePlanCls = {
+  'PERSONAL': '개인',
+  'COMPANY': '전사',
+  'PROPOSAL': '제안',
+  'ESTIMATE': '견적',
+  'SALES': '매출',
+  'CONTRACT': '계약'
+};
+
+export const categoryColors = {
+  'PERSONAL': '#f7eaa4',
+  'COMPANY': '#dde2a9',
+  'PROPOSAL': '#9ed7a9',
+  'ESTIMATE': '#ccd5db',
+  'SALES': '#a4bbe1',
+  'CONTRACT': '#a4cbe8'
+};

--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -11,6 +11,7 @@ import { useCalendarStore } from '@/stores/apps/calendar/calendar';
 import baseApi from '@/api/baseapi';
 import api from '@/api/axiosinterceptor';
 import { reverseActStatus, actStatus } from '@/utils/ActStatusMappings';
+import {planClsMapping, reversePlanCls} from '@/utils/PlanMappings'
 import axios from 'axios';
 
 export default defineComponent({
@@ -211,8 +212,8 @@ export default defineComponent({
       }
       this.showAlert = false;
       const setPersonalYn = {
-        ...plan,
-        personalYn: plan.personalYn ? 'Y' : 'N',
+        ...this.plan,
+        personalYn: this.plan.personalYn ? 'Y' : 'N',
       };
       try {
         const response = await api.post('/plans', setPersonalYn);
@@ -288,6 +289,8 @@ export default defineComponent({
         endTime: '',
         personalYn: 'N',
         content: '',
+				title: '',
+				note: '',
       };
     },
   // 클릭 이벤트
@@ -309,7 +312,7 @@ export default defineComponent({
           this.plan = {          
             calendarNo: planDetails.calendarNo,          
             title: planDetails.title,
-            planCls: planDetails.planCls,
+            planCls: reversePlanCls[planDetails.planCls],
             planDate: planDetails.planDate,          
             startTime: planDetails.startTime,          
             endTime: planDetails.endTime,         

--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -50,7 +50,7 @@ export default defineComponent({
         planDate: '',
         startTime: '',
         endTime: '',
-        personalYn: 'N',
+        personalYn: 'Y',
         content: '',
       },
       calendarOptions: {


### PR DESCRIPTION
## 💬 작업 내용 설명
- Plan 분류에 도메인(매출, 제안, 견적, 계약) 연결 기능 추가
- 관련 컴포넌트 추가
- Plan에 나만보기 여부 반영


<details>
  <summary> 도메인 선택 시 목록 모달 </summary>

![image](https://github.com/user-attachments/assets/fdc712a8-0342-4988-a743-99460ff19197)

</details>

<details>
  <summary> 각 분류의 제목 및 내용 </summary>

![image](https://github.com/user-attachments/assets/1c9786b8-e854-40f7-b3cb-dc51471ebe5b)

</details>


<details>
  <summary> 전사 및 일정일 땐 x</summary>

![image](https://github.com/user-attachments/assets/ec64566d-e889-4f53-aa8b-7be1743b1959)

</details>

<br>

## #️⃣연관된  issue
close #87

<br>

## ✅ 체크리스트
- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링

<br>
