### PR TITLE
[Feat/#41] 로그인한 사용자의 캘린더 관리

### DIFF
--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -106,7 +106,7 @@ export default defineComponent({
       try {
         const response = await api.post('/calendars');
       } catch (e) {
-        console.error('캘린더 생성 중 오류 발생:', e);
+        console.error(e);
       }
     },
 
@@ -137,7 +137,6 @@ export default defineComponent({
       try {
         const response = await api.get('/calendars/user/data');
         const calendarData = response.data.result;
-        console.log('response',response.data.result.todos);
         this.calendarNo = response.data.result.calendarNo;
 
         const store = useCalendarStore();
@@ -173,7 +172,6 @@ export default defineComponent({
 
         store.setCalendarData([...todos, ...plans, ...acts]);
         this.applyFilter(store.filteredData);
-        console.log('필터',store.filteredData)
 
       } catch (e) {
         console.error(e);
@@ -199,8 +197,6 @@ export default defineComponent({
 
       try {
         const response = await api.post('/todos', setPrivateYn);
-        console.log('Todo 추가 데이터:', setPrivateYn); 
-        console.log('할 일 추가 성공:', response);
         const createdTodo = response.data.result;
         const calendarApi = this.$refs.calendar.getApi();
         calendarApi.addEvent({
@@ -233,7 +229,6 @@ export default defineComponent({
       };
       try {
         const response = await api.post('/plans', setPersonalYn);
-        console.log('일정 추가 성공:', response.data);
         const createdPlan = response.data.result;
         const calendarApi = this.$refs.calendar.getApi();
         const className = `${plan.planCls.toLowerCase()}_plan-event`;
@@ -268,7 +263,6 @@ export default defineComponent({
     },
 
   async updatePlan(updatedPlan) {
-    console.log('updatedPlan.planNo',updatedPlan)
     const calendarApi = this.$refs.calendar.getApi();
     const event = calendarApi.getEventById(updatedPlan.planNo);
 
@@ -335,13 +329,11 @@ export default defineComponent({
     async handleEventClick(clickInfo) {
       const eventId = clickInfo.event.id;    
       const eventClassNames = clickInfo.event.classNames;
-      console.log('eventClassNames,', eventClassNames)
       if (eventClassNames.some(className => className.includes('plan'))) {
         this.AddPlanModal = true;
         this.mode = 'edit';
         try {        
           const response = await api.get(`/plans/${eventId}`);  
-          console.log('get',response)      
           const planDetails = response.data.result;
           this.plan = {     
             planNo: planDetails.planNo,
@@ -434,7 +426,6 @@ export default defineComponent({
         const event = calendarApi.getEventById(planToDelete.planNo);
         if (event) {
           event.remove();
-          console.log('Event removed:', planToDelete.planNo);
         }
         this.closePlanModal();
         this.handleAlert({


### PR DESCRIPTION
## 💬 작업 내용 설명
- 사용자의 캘린더 존재 여부를 확인하는 로직 추가
- 캘린더 데이터를 통해 일정, 할 일, 영업활동 데이터를 통합 조회하도록 수정
- 로그인한 사용자의 calendarNo를 기반으로 일정 및 할 일 추가하도록 수정

<br>

<details>
  <summary> 캘린더 </summary>

![image](https://github.com/user-attachments/assets/5f252e44-c528-489c-a23b-d079a4447a6a)

</details>

<br>

## #️⃣연관된  issue
close #41

<br>

## ✅ 체크리스트
- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정

<br>

## 📑To Reviewers
- PLAN update 분류 `개인 및 전사 외 분류` -> `개인/전사`로 변경 시 text-field 뜨는 문제
- 시간 값 유효성 검증(시작하는 시간이 끝나는 시간보다 늦으면x)
만 해결하고 추가하면 기본 캘린더 끝입니다..
일단 백엔드 테스트 수행 후 고치도록 하겠습니다 
