### PR TITLE
[Refact/136] 공통 컴포넌트 및 레이아웃 통일 작업

### DIFF
--- a/src/components/customer/InputForm.vue
+++ b/src/components/customer/InputForm.vue
@@ -4,7 +4,10 @@ import axios from 'axios';
 import { useRouter } from 'vue-router';
 import { mask } from 'maska';  
 import api from '@/api/axiosinterceptor';
-import BaseButton from '../BaseButton.vue';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const userName = ref();
 const grades = ref(['S등급', 'A등급','B등급','C등급','D등급']);
@@ -39,15 +42,21 @@ const registerAPI = async()=>{
         }
      )
         if(res.data.code==200){
-            alert(res.data.result);
-            router.push({
-                name: "Customer"
-            });
+            triggerAlert(`${res.data.result}`, 'success');
+            
+            setTimeout(() => {
+                router.push({ name: 'Customer' });
+            }, 2000);
+            // alert(res.data.result);
+            // router.push({
+            //     name: "Customer"
+            // });
         }else{
             alert(res.data.result);
         }  
     }catch(err){
         console.log(`[ERROR 메세지] : ${err}`);
+        triggerAlert('등록에 실패했습니다.', 'error');
 
     }
 }
@@ -80,6 +89,7 @@ onMounted(()=>{
 
 </script>
 <template>
+  <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <v-row>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">고객명</v-label><span class="require">*</span>

--- a/src/components/customer/InputForm.vue
+++ b/src/components/customer/InputForm.vue
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { useRouter } from 'vue-router';
 import { mask } from 'maska';  
 import api from '@/api/axiosinterceptor';
+import BaseButton from '../BaseButton.vue';
 
 const userName = ref();
 const grades = ref(['S등급', 'A등급','B등급','C등급','D등급']);
@@ -46,7 +47,7 @@ const registerAPI = async()=>{
             alert(res.data.result);
         }  
     }catch(err){
-        console.log(`[ERROR 몌세지] : ${err}`);
+        console.log(`[ERROR 메세지] : ${err}`);
 
     }
 }
@@ -139,8 +140,8 @@ onMounted(()=>{
 
     </v-row>
     <div class="d-flex gap-3 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
-            <v-btn color="info" variant="outlined" to="/sales/contact">목록</v-btn>
-            <v-btn color="primary" variant="outlined" @click="registerCustomer" :disabled="!formIsValid">고객 등록</v-btn>
+        <v-btn color="primary" variant="flat" @click="registerCustomer" :disabled="!formIsValid">고객 등록</v-btn>
+        <v-btn color="info" variant="outlined" to="/sales/contact">목록으로 돌아가기</v-btn>
     </div>   
 </template>
 <style scoped>

--- a/src/components/customer/UpdateForm.vue
+++ b/src/components/customer/UpdateForm.vue
@@ -163,9 +163,9 @@ const formIsValid = computed(()=>{
         </v-col>
 
     </v-row>
-    <div class="d-flex gap-3 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
-            <v-btn color="info" variant="outlined" to="/sales/contact">목록</v-btn>
-            <v-btn color="primary" variant="outlined" @click="updateCustomer" :disabled="!formIsValid">고객 정보 수정</v-btn>
+    <div class="d-flex gap-2 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
+        <v-btn color="primary" variant="flat" @click="updateCustomer" :disabled="!formIsValid">수정</v-btn>
+        <v-btn color="info" variant="outlined" to="/sales/contact">목록으로 돌아가기</v-btn>
     </div>   
 </template>
 <style scoped>

--- a/src/components/customer/UpdateForm.vue
+++ b/src/components/customer/UpdateForm.vue
@@ -2,7 +2,12 @@
 import { computed, onMounted, ref ,nextTick } from 'vue';
 import api from '@/api/axiosinterceptor';
 import { useRouter ,useRoute} from 'vue-router';
-import { mask } from 'maska';  
+import { mask } from 'maska'; 
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+import EditConfirmDialog from '../../components/shared/EditConfirmDialog.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const userName = ref();
 const grades = ref(['S등급', 'A등급','B등급','C등급','D등급']);
@@ -16,6 +21,8 @@ const tel = ref(null);
 const grade = ref(null);
 const isKeyMan = ref(false);
 
+const showEditConfirmDialog = ref(false);
+
 const router = useRouter();
 const route = useRoute();
 
@@ -23,9 +30,11 @@ onMounted(()=>{
     getCustomerInfoAPI(route.params.id);
 })
 const updateCustomer = ()=>{
-    if(confirm("고객정보를 수정하시겠습니까?")){
-        updateCustomerAPI(route.params.id);
-    }
+
+    showEditConfirmDialog.value = true; 
+//     if(confirm("고객정보를 수정하시겠습니까?")){
+//         updateCustomerAPI(route.params.id);
+//     }
 }
 
 const getCustomerInfoAPI = async(id: string | string[])=>{
@@ -50,7 +59,7 @@ const getCustomerInfoAPI = async(id: string | string[])=>{
         
         }
     }catch(err){
-        console.log(`[ERROR 몌세지] : ${err}`);
+        console.log(`[ERROR 메세지] : ${err}`);
     }
 }
 
@@ -69,12 +78,16 @@ const updateCustomerAPI = async(id:string|string[])=>{
         })
         console.log(response.data);
         if(response.data.code==200){
-            alert(response.data.result);
-            getCustomerInfoAPI(route.params.id);
+            triggerAlert('수정이 완료되었습니다.', 'success');
+            // getCustomerInfoAPI(route.params.id);
+            showEditConfirmDialog.value = false; 
+            setTimeout(() => {
+                router.push({ name: "Customer" });
+            }, 2000); 
         }
 
     }catch(err){
-        console.log(`[ERROR 몌세지] : ${err}`);
+        console.log(`[ERROR 메세지] : ${err}`);
     }
 
 }
@@ -104,6 +117,7 @@ const formIsValid = computed(()=>{
 
 </script>
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <v-row>
         <v-col cols="6">
             <v-label class="font-weight-medium mb-2">고객명</v-label><span class="require">*</span>
@@ -163,6 +177,14 @@ const formIsValid = computed(()=>{
         </v-col>
 
     </v-row>
+
+    <EditConfirmDialog
+        :dialog="showEditConfirmDialog"
+        message="고객정보를 수정하시겠습니까?"
+        @confirm="updateCustomerAPI(route.params.id)"
+        @close="showEditConfirmDialog = false"
+    />
+
     <div class="d-flex gap-2 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
         <v-btn color="primary" variant="flat" @click="updateCustomer" :disabled="!formIsValid">수정</v-btn>
         <v-btn color="info" variant="outlined" to="/sales/contact">목록으로 돌아가기</v-btn>

--- a/src/components/estimate/CreateEstimate.vue
+++ b/src/components/estimate/CreateEstimate.vue
@@ -8,9 +8,10 @@ import api from '@/api/axiosinterceptor';
 const router = useRouter();
 const route = useRoute();
 
+const page = ref({ title: '견적 등록' });
 const breadcrumbs = ref([
-    { text: '견적 리스트', disabled: false, href: '/estimates' },
-    { text: '새로운 견적 등록', disabled: true, href: '/estimates/detail' }
+    { text: '견적 목록', disabled: false, href: '/estimates' },
+    { text: '견적 등록', disabled: true, href: '/estimates/detail' }
 ]);
 
 const valid = ref(false);
@@ -181,7 +182,7 @@ const warningAlert = ref(false);
         </v-card>
     </v-dialog>
     <div>
-        <BaseBreadcrumb :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
+        <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
 
         <v-container>
             <v-row>
@@ -231,7 +232,7 @@ const warningAlert = ref(false);
                                 <v-dialog v-model="proposalModal" max-width="600px">
                                     <v-card>
                                         <v-card-title class="d-flex justify-space-between">
-                                            <span>제안 리스트</span>
+                                            <span>제안 목록</span>
                                             <v-btn icon @click="closeProposalModal">
                                                 <v-icon>mdi-close</v-icon>
                                             </v-btn>
@@ -342,6 +343,21 @@ const warningAlert = ref(false);
                 <v-col cols="12" md="6" class="d-flex align-stretch">
                     <UiParentCard title="제품 등록" class="fill-height">
                         <v-form ref="form" v-model="valid" @submit.prevent="save">
+                            <!-- 제품 (Product) -->
+                            <v-row>
+                                <v-col class="ml-3" cols="12" sm="6">
+                                    <v-text-field
+                                        v-model="createItem.prodName"
+                                        label="선택된 제품"
+                                        :rules="[(v) => !!v || '제품을 선택해주세요']"
+                                        readonly
+                                        outlined
+                                    ></v-text-field>
+                                    </v-col>
+                                    <v-col cols="12" sm="4">
+                                    <v-btn color="primary" @click="openProductModal">제품 선택</v-btn>
+                                </v-col>
+                            </v-row>
                             <!-- 단가 -->
                             <v-col cols="12" sm="6">
                                 <v-text-field
@@ -445,26 +461,15 @@ const warningAlert = ref(false);
                                     </v-card-text>
                                 </v-card>
                             </v-dialog>
-                            <!-- 제품 (Product) -->
-                            <v-col cols="12" sm="6">
-                                <v-text-field
-                                    v-model="createItem.prodName"
-                                    label="선택된 제품"
-                                    :rules="[(v) => !!v || '제품을 선택해주세요']"
-                                    readonly
-                                    outlined
-                                ></v-text-field>
-                                <v-btn color="primary" @click="openProductModal">제품 선택</v-btn>
-                            </v-col>
                         </v-form>
                     </UiParentCard>
                 </v-col>
             </v-row>
             <v-row justify="end">
-                <v-col cols="2" sm="2">
-                    <v-btn color="success" class="mr-3" flat @click="cancel">취소</v-btn>
-                    <v-btn color="info" class="mr-3" flat @click="save">저장</v-btn>
-                </v-col>
+                    <v-btn color="primary" class="mr-2" flat @click="save">저장</v-btn>
+                    <v-btn class="mr-3" variant="outlined" color="primary" @click="cancel">목록으로 돌아가기</v-btn>
+                    <!-- <BaseButton class="mr-2" label="저장" type="save" context="form" @click="save"/>
+                    <BaseButton class="mr-3" label="목록으로 돌아가기" type="back" context="form" @click="cancel"/> -->
             </v-row>
         </v-container>
     </div>

--- a/src/components/estimate/CreateEstimate.vue
+++ b/src/components/estimate/CreateEstimate.vue
@@ -5,6 +5,11 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import api from '@/api/axiosinterceptor';
 
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 const router = useRouter();
 const route = useRoute();
 
@@ -124,8 +129,9 @@ const save = async () => {
 
     try {
         const response = await api.post('/estimates', createItem.value);
-        successAlert.value = true;
-        alertDialog.value = true;
+        // successAlert.value = true;
+        // alertDialog.value = true;
+          triggerAlert('견적이 등록되었습니다.', 'success', 2000,'/estimates');
 
         const newEstimate = response.data;
 
@@ -135,11 +141,12 @@ const save = async () => {
         }));
 
         await api.post('/estProducts', productsToSave);
+        // triggerAlert('견적이 수정되었습니다.', 'success', 2000,'/estimates');
 
-        successAlert.value = true;
-        alertDialog.value = true;
+        // successAlert.value = true;
+        // alertDialog.value = true;
 
-        setTimeout(() => router.push('/estimates'), 1500);
+        // setTimeout(() => router.push('/estimates'), 1500);
     } catch (error) {
         console.error('Failed to create estimate:', error.response ? error.response.data : error.message);
         errorAlert.value = true;
@@ -160,27 +167,8 @@ const warningAlert = ref(false);
 <style scoped></style>
 
 <template>
-    <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
-        <v-card>
-            <v-card-text>
-                <v-alert v-if="successAlert" type="success" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Success</h5>
-                    <div>견적이 성공적으로 등록되었습니다.</div>
-                </v-alert>
-                <v-alert v-if="errorAlert" type="error" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Error</h5>
-                    <div>견적 등록에 실패했습니다. 다시 시도해주세요.</div>
-                </v-alert>
-                <v-alert v-if="warningAlert" type="warning" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Warning</h5>
-                    <div>필수 항목을 입력해주세요.</div>
-                </v-alert>
-            </v-card-text>
-            <v-card-actions>
-                <v-btn color="primary" block @click="alertDialog = false" flat>Close</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+
+<AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div>
         <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
 

--- a/src/components/estimate/DetailEstimate.vue
+++ b/src/components/estimate/DetailEstimate.vue
@@ -9,7 +9,7 @@ const router = useRouter();
 const route = useRoute();
 
 const breadcrumbs = ref([
-    { text: '견적 리스트', disabled: false, href: '/estimates' },
+    { text: '견적 목록', disabled: false, href: '/estimates' },
     { text: '견적 상세페이지', disabled: true, href: '/estimates/form' }
 ]);
 
@@ -307,7 +307,7 @@ const warningAlert = ref(false);
                                 <v-dialog v-model="proposalModal" max-width="600px">
                                     <v-card>
                                         <v-card-title class="d-flex justify-space-between">
-                                            <span>제안 리스트</span>
+                                            <span>제안 목록</span>
                                             <v-btn icon @click="closeProposalModal">
                                                 <v-icon>mdi-close</v-icon>
                                             </v-btn>
@@ -539,10 +539,8 @@ const warningAlert = ref(false);
 
         <!-- 제출 -->
         <v-row justify="end">
-            <v-col cols="2" sm="2">
-                <v-btn color="success" class="mr-3" flat @click="cancel">취소</v-btn>
-                <v-btn color="info" class="mr-3" flat @click="save">저장</v-btn>
-            </v-col>
+            <v-btn class="mr-2 mt-2" color="primary" variant="flat" style="font-size: 15px; font-weight: 600;" @click="save">저장</v-btn>
+            <v-btn class="mr-7 mt-2" color="primary" variant="outlined" style="font-size: 15px; font-weight: 600;" @click="cancel">목록으로 돌아가기</v-btn>
         </v-row>
     </div>
 </template>

--- a/src/components/estimate/DetailEstimate.vue
+++ b/src/components/estimate/DetailEstimate.vue
@@ -4,6 +4,10 @@ import { useRouter, useRoute } from 'vue-router';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import api from '@/api/axiosinterceptor';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const router = useRouter();
 const route = useRoute();
@@ -213,10 +217,10 @@ const save = async () => {
 
         await api.patch('/estProducts', productsToSave);
 
-        successAlert.value = true;
-        alertDialog.value = true;
-
-        setTimeout(() => router.push('/estimates'), 1500);
+        triggerAlert('견적이 수정되었습니다.', 'success', 2000,'/estimates');
+        // successAlert.value = true;
+        // alertDialog.value = true;
+        // setTimeout(() => router.push('/estimates'), 1500);
     } catch (error) {
         console.error('Failed to update estimate:', error.response ? error.response.data : error.message);
 
@@ -236,27 +240,7 @@ const warningAlert = ref(false);
 </script>
 
 <template>
-    <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
-        <v-card>
-            <v-card-text>
-                <v-alert v-if="successAlert" type="success" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Success</h5>
-                    <div>견적이 성공적으로 수정되었습니다.</div>
-                </v-alert>
-                <v-alert v-if="errorAlert" type="error" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Error</h5>
-                    <div>견적 수정에 실패했습니다. 다시 시도해주세요.</div>
-                </v-alert>
-                <v-alert v-if="warningAlert" type="warning" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Warning</h5>
-                    <div>필수 항목을 입력해주세요.</div>
-                </v-alert>
-            </v-card-text>
-            <v-card-actions>
-                <v-btn color="primary" block @click="alertDialog = false" flat>Close</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div>
         <BaseBreadcrumb :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
 

--- a/src/components/estimate/EstimateList.vue
+++ b/src/components/estimate/EstimateList.vue
@@ -6,6 +6,10 @@ import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
 import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 const showConfirmDialogs = ref(false); // 열림 상태 관리
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const page = ref({ title: '견적 목록' });
 
@@ -22,10 +26,10 @@ const breadcrumbs = ref([
 	},
 ]);
 const dialogDelete = ref(false);
-const estimates = ref([]);
 const proposals = ref([]);
 const estProducts = ref([]);
 const products = ref([]);
+const estimates = ref([]);
 const dialogEdit = ref(false);
 const editedIndex = ref(-1);
 
@@ -104,14 +108,14 @@ const submitEstimateApi = async () => {
     const res = await api.post('/estimates', editedItem.value);
     console.log(res);
     if (res.status === 200) {
-      alert("견적이 성공적으로 등록되었습니다.");
+      triggerAlert('견적이 등록되었습니다.', 'success', 2000,'/estimates');
       await initialize(); 
       resetForm();
       router.push('/estimates');
     }
   } catch (error) {
     console.error("등록 실패:", error);
-    alert("견적 등록에 실패했습니다.");
+    triggerAlert('견적 등록을 실패했습니다.', 'error', 2000);
   }
 };
 
@@ -119,11 +123,11 @@ const updateEstimateApi = async () => {
     try {
         const res = await api.patch(`/estimates/${editedItem.value.estNo}`, editedItem.value);
         if (res.status === 200) {
-            alert("견적이 성공적으로 수정되었습니다.");
+          triggerAlert('견적이 수정되었습니다.', 'success', 2000,'/estimates');
             // Object.assign(estimates.value[editedIndex.value], res.data);
             await initialize();
             resetForm();
-            router.push('/estimates');
+            // router.push('/estimates');
             dialogEdit.value = false;
         }
     } catch (error) {
@@ -156,13 +160,13 @@ const displayedEstimates = computed(() => estimates.value);
 const deleteEstimateApi = async () => {
     try {
         await api.delete(`/estimates/${editedItem.value.estNo}`);
-        alert("견적이 성공적으로 삭제되었습니다.");
+        triggerAlert('견적이 삭제되었습니다.', 'success', 2000,'/estimates');
         estimates.value.splice(editedIndex.value, 1);
         resetForm();
         router.push('/estimates');
     } catch (error) {
         console.error("삭제 실패:", error);
-        alert("견적 삭제에 실패했습니다.");
+        triggerAlert('견적이 삭제되었습니다.', 'error');
     }
 };
 
@@ -200,6 +204,7 @@ initialize();
 </script>
 
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
   <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
     <v-row>
       <v-col cols="12">

--- a/src/components/estimate/EstimateList.vue
+++ b/src/components/estimate/EstimateList.vue
@@ -4,6 +4,8 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
+const showConfirmDialogs = ref(false); // 열림 상태 관리
 
 const page = ref({ title: '견적 목록' });
 
@@ -178,16 +180,19 @@ const createNewEstimate = () => {
 const deleteItem = (item) => {
     editedItem.value = { ...item };
     editedIndex.value = estimates.value.indexOf(item);
-    dialogDelete.value = true;
+    // dialogDelete.value = true;
+    showConfirmDialogs.value = true;
 };
 
 const confirmDelete = async () => {
     await deleteEstimateApi();
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 const closeDeleteDialog = () => {
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 initialize();
@@ -269,16 +274,6 @@ initialize();
     </v-dialog>
 
     <!-- 삭제 -->
-    <v-dialog v-model="dialogDelete" max-width="500px">
-      <v-card>
-        <v-card-title class="text-h5 text-center py-6">선택한 견적을 정말 삭제하시겠습니까?</v-card-title>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn color="warning" variant="flat" @click="closeDeleteDialog">취소</v-btn>
-          <v-btn color="success" variant="flat" @click="confirmDelete">삭제</v-btn>
-          <v-spacer></v-spacer>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDelete" @disagree="closeDeleteDialog" />
   </template>
   

--- a/src/components/estimate/EstimateList.vue
+++ b/src/components/estimate/EstimateList.vue
@@ -5,12 +5,20 @@ import UiParentCard from '@/components/shared/UiParentCard.vue';
 import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
 
-const page = ref({ title: '견적 리스트' });
-const breadcrumbs = ref([
-    { text: '영업관리', disabled: false, href: '' }, 
-    { text: '견적', disabled: true, href: '/estimates' },
-]);
+const page = ref({ title: '견적 목록' });
 
+const breadcrumbs = ref([
+{
+	text: '영업관리',
+	disabled: false,
+	to: '#'
+},
+{
+	text: '견적',
+	disabled: true,
+	to: ''
+	},
+]);
 const dialogDelete = ref(false);
 const estimates = ref([]);
 const proposals = ref([]);
@@ -73,7 +81,7 @@ const headers = ref([
     { title: '', key: 'actions', sortable: false },
 ]);
 
-const formTitle = computed(() => (editedIndex.value === -1 ? '추가' : '수정'));
+const formTitle = computed(() => (editedIndex.value === -1 ? '견적 추가' : '견적 수정'));
 
 const router = useRouter();
 
@@ -187,7 +195,7 @@ initialize();
 </script>
 
 <template>
-    <BaseBreadcrumb :title="page.title" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
+  <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
     <v-row>
       <v-col cols="12">
         <UiParentCard title="견적">
@@ -199,12 +207,13 @@ initialize();
             item-key="estNo"
             show-actions
           >
-            <template v-slot:top>
-              <v-toolbar class="bg-lightsecondary" flat>
-                <v-toolbar-title>등록된 견적 리스트</v-toolbar-title>
+          <template v-slot:top>
+              <v-row justify="end">
+                <v-col cols="auto">
                 <v-spacer></v-spacer>
-                <v-btn color="primary" variant="flat" @click="navigateToCreate">새로운 견적 등록</v-btn>
-              </v-toolbar>
+                <v-btn color="primary" class="mr-3 mt-4" variant="tonal" @click="navigateToCreate">견적 생성</v-btn>
+              </v-col>
+              </v-row>
             </template>
 
             <template v-slot:item.actions="{ item }">
@@ -236,7 +245,7 @@ initialize();
     <!-- 수정 -->
     <v-dialog v-model="dialogEdit" max-width="500px">
       <v-card>
-        <v-card-title class="text-h5 text-center py-6">{{ formTitle }}</v-card-title>
+        <v-card-title>{{ formTitle }}</v-card-title>
         <v-card-text>
           <v-form>
             <v-text-field v-model="editedItem.name" label="견적명" required></v-text-field>
@@ -253,9 +262,8 @@ initialize();
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="warning" variant="flat" @click="closeEditDialog">취소</v-btn>
-        <v-btn color="success" variant="flat" @click="save">저장</v-btn>
-        <v-spacer></v-spacer>
+        <v-btn color="primary" variant="outlined" style="font-size: 15px; font-weight: 600;" @click="save">수정</v-btn>
+        <v-btn color="close" variant="flat" style="font-size: 15px; font-weight: 600;" @click="closeEditDialog">닫기</v-btn>
       </v-card-actions>
     </v-card>
     </v-dialog>

--- a/src/components/estimate/ListEstimate.vue
+++ b/src/components/estimate/ListEstimate.vue
@@ -177,9 +177,7 @@ const warningAlert = ref(false);
                     </v-col>
                     <v-spacer></v-spacer>
                     <v-col cols="auto">
-                        <v-btn color="primary" variant="flat" class="mr-2 mdi text-h6 mdi-plus-outline" @click="navigateToCreate"
-                            >새로운 견적 등록</v-btn
-                        >
+                        <v-btn color="primary" variant="flat" class="mr-2" @click="navigateToCreate">견적 생성</v-btn>
                     </v-col>
                 </v-row>
 
@@ -193,19 +191,20 @@ const warningAlert = ref(false);
                     show-actions
                 >
                     <template v-slot:item.actions="{ item }">
-                        <v-icon
-                            color="info"
+                        <EditIcon
+                            height="20"
+                            width="20"
+                            class="mr-2 text-primary cursor-pointer"
                             size="small"
-                            class="me-2"
                             @click="goToDetailEstimate(item.estNo)"
-                            role="button"
-                            aria-label="Edit Estimate"
-                        >
-                            mdi-pencil
-                        </v-icon>
-                        <v-icon color="error" size="small" @click="deleteItem(item)" role="button" aria-label="Delete Estimate">
-                            mdi-delete
-                        </v-icon>
+                        />
+                        <TrashIcon
+                            height="20"
+                            width="20"
+                            class="text-error cursor-pointer"
+                            size="small"
+                            @click="deleteItem(item)"
+                        />
                     </template>
                 </v-data-table>
             </v-card>

--- a/src/components/estimate/ListEstimate.vue
+++ b/src/components/estimate/ListEstimate.vue
@@ -6,6 +6,11 @@ import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
 import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 const showConfirmDialogs = ref(false); // 열림 상태 관리
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 
 const page = ref({ title: '' });
 
@@ -81,17 +86,18 @@ const deleteEstimateApi = async () => {
     try {
         await api.delete(`/estimates/${editedItem.value.estNo}`);
 
-        successAlert.value = true;
-        alertDialog.value = true;
+        // successAlert.value = true;
+        // alertDialog.value = true;
 
-        setTimeout(() => router.push('/estimates'), 1500);
+        triggerAlert('견적이 삭제되었습니다.', 'success', 2000,'/estimates');
 
         estimates.value.splice(editedIndex.value, 1);
         resetForm();
-        router.push('/estimates');
+        // router.push('/estimates');
     } catch (error) {
-        errorAlert.value = true;
-        alertDialog.value = true;
+        // errorAlert.value = true;
+        // alertDialog.value = true;
+    triggerAlert('견적 삭제를 실패했습니다.', 'error', 2000);
     }
 };
 
@@ -127,27 +133,8 @@ const warningAlert = ref(false);
 </script>
 
 <template>
-    <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
-        <v-card>
-            <v-card-text>
-                <v-alert v-if="successAlert" type="success" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Success</h5>
-                    <div>견적이 성공적으로 삭제되었습니다.</div>
-                </v-alert>
-                <v-alert v-if="errorAlert" type="error" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Error</h5>
-                    <div>견적 삭제에 실패했습니다. 다시 시도해주세요.</div>
-                </v-alert>
-                <v-alert v-if="warningAlert" type="warning" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Warning</h5>
-                    <div>필수 항목을 입력해주세요.</div>
-                </v-alert>
-            </v-card-text>
-            <v-card-actions>
-                <v-btn color="primary" block @click="alertDialog = false" flat>Close</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <BaseBreadcrumb :title="page.title" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
     <v-row>
         <!-- 검색 -->

--- a/src/components/estimate/ListEstimate.vue
+++ b/src/components/estimate/ListEstimate.vue
@@ -4,6 +4,8 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
+const showConfirmDialogs = ref(false); // 열림 상태 관리
 
 const page = ref({ title: '' });
 
@@ -101,16 +103,19 @@ const resetForm = () => {
 const deleteItem = (item) => {
     editedItem.value = { ...item };
     editedIndex.value = estimates.value.indexOf(item);
-    dialogDelete.value = true;
+    // dialogDelete.value = true;
+    showConfirmDialogs.value = true;
 };
 
 const confirmDelete = async () => {
     await deleteEstimateApi();
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 const closeDeleteDialog = () => {
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 initialize();
@@ -211,17 +216,7 @@ const warningAlert = ref(false);
         </v-col>
     </v-row>
 
-    <v-dialog v-model="dialogDelete" max-width="500px">
-        <v-card>
-            <v-card-title class="text-h5 text-center py-6">선택한 견적을 정말 삭제하시겠습니까?</v-card-title>
-            <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="warning" variant="flat" @click="closeDeleteDialog">취소</v-btn>
-                <v-btn color="success" variant="flat" @click="confirmDelete">삭제</v-btn>
-                <v-spacer></v-spacer>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    <ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDelete" @disagree="closeDeleteDialog" />
 </template>
 
 <style>

--- a/src/components/lead/DetailForm.vue
+++ b/src/components/lead/DetailForm.vue
@@ -2,6 +2,9 @@
 import { computed, ref, onMounted, reactive, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
+
+const showConfirmDialogs = ref(false); // 열림 상태 관리
 
 const route = useRoute();
 const router = useRouter();
@@ -274,7 +277,8 @@ const deleteDialog = ref(false);
 
 const deleteLead = async () => {
     const leadNo = leadResponseDto.leadNo;
-    deleteDialog.value = false;
+    // deleteDialog.value = false;
+    showConfirmDialogs.value = false;
     if (leadNo) {
         try {
             await api.delete(`/leads/${leadNo}`);
@@ -430,6 +434,8 @@ onMounted(() => {
 
 <template>
     <v-card elevation="10">
+        <ConfirmDialogs :dialog="showConfirmDialogs" @agree="deleteLead" @disagree="() => (showConfirmDialogs = false)" />
+
         <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
             <v-card>
                 <v-card-text>
@@ -448,17 +454,6 @@ onMounted(() => {
                 </v-card-text>
                 <v-card-actions>
                     <v-btn color="primary" block @click="alertDialog = false" flat>Close</v-btn>
-                </v-card-actions>
-            </v-card>
-        </v-dialog>
-        <v-dialog v-model="deleteDialog" max-width="500" class="dialog-mw">
-            <v-card>
-                <v-card-title class="headline">경고</v-card-title>
-                <v-card-text> 이 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다. </v-card-text>
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn color="primary" tonal @click="deleteLead">삭제</v-btn>
-                    <v-btn color="error" tonal @click="deleteDialog = false">취소</v-btn>
                 </v-card-actions>
             </v-card>
         </v-dialog>
@@ -645,7 +640,7 @@ onMounted(() => {
                             <v-text-field variant="outlined" color="primary" placeholder="상세 주소"></v-text-field>
                         </div>
                         <v-btn color="primary" class="mr-2" flat @click="submitForm">{{ saveBtn }}</v-btn>
-                        <v-btn v-if="saveBtn == '수정'" color="error" class="mr-2"  @click="deleteDialog = true">삭제</v-btn>
+                        <v-btn v-if="saveBtn == '수정'" color="error" class="mr-2"  @click="showConfirmDialogs = true">삭제</v-btn>
                         <v-btn class="ml-" variant="outlined" color="primary" to="/sales/lead">목록으로 돌아가기</v-btn>
                     </v-col>
                     <v-col cols="12" md="6">

--- a/src/components/lead/DetailForm.vue
+++ b/src/components/lead/DetailForm.vue
@@ -644,9 +644,9 @@ onMounted(() => {
                             <v-text-field v-model="leadResponseDto.addr" variant="outlined" color="primary"></v-text-field>
                             <v-text-field variant="outlined" color="primary" placeholder="상세 주소"></v-text-field>
                         </div>
-                        <v-btn color="primary" class="mr-3" flat @click="submitForm">{{ saveBtn }}</v-btn>
-                        <v-btn v-if="saveBtn == '수정'" color="error" class="mr-3" flat @click="deleteDialog = true">삭제</v-btn>
-                        <v-btn color="success" class="mr-3" flat to="/sales/lead">목록</v-btn>
+                        <v-btn color="primary" class="mr-2" flat @click="submitForm">{{ saveBtn }}</v-btn>
+                        <v-btn v-if="saveBtn == '수정'" color="error" class="mr-2"  @click="deleteDialog = true">삭제</v-btn>
+                        <v-btn class="ml-" variant="outlined" color="primary" to="/sales/lead">목록으로 돌아가기</v-btn>
                     </v-col>
                     <v-col cols="12" md="6">
                         <v-label class="mb-2 font-weight-medium">영업종료일</v-label>

--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -6,7 +6,7 @@
 				<v-form @submit.prevent="submitPlan" lazy-validation>
 					<div>
 						<v-alert v-if="showAlert" type="warning" variant="tonal" class="warn-alert">
-							<h5 class="text-h6 text-capitalize">warning</h5>
+							<h5 class="text-h5 text-capitalize">warning</h5>
 							<div>{{ alertMessage }}</div>
 						</v-alert>
 					</div>
@@ -340,6 +340,7 @@ export default {
 	transform: translateX(-50%);
 	z-index: 3000;
 	width: 60%;
+	font-size: 16px;
 }
 .headline {
 	padding-top: 20px;

--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -73,11 +73,12 @@
 			</v-card-text>
 			<ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDelete" @disagree="cancleDelete" />
 			<v-card-actions>
+					<v-btn v-if="mode === 'edit'" color="primary" variant="outlined" @click="updatePlan" flat style="font-size: 15px; font-weight: 600;">수정</v-btn>
+					<v-btn v-if="mode === 'edit'" color="error" variant="outlined" @click="deletePlan" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
 				<v-spacer></v-spacer>
-					<v-btn color="close" @click="closeModal">Close</v-btn>
-					<v-btn v-if="mode === 'add'" color="success" variant="text" @click="submitPlan" flat>Save</v-btn>
-					<v-btn v-else-if="mode === 'edit'" color="success" variant="text" @click="updatePlan" flat>Update</v-btn>
-					<v-btn v-if="mode === 'edit'" color="error" variant="text" @click="deletePlan" flat>Delete</v-btn>
+					<v-btn v-if="mode === 'add'" color="primary"@click="addTodo" flat style="font-size: 15px; font-weight: 600;">저장</v-btn>
+					<v-btn color="close" @click="closeModal" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
+
 					<ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDelete" @disagree="cancleDelete" />
 			</v-card-actions>
 		</v-card>

--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -116,7 +116,7 @@
 <script>
 import '@/views/apps/calendar/calendar.css';
 import api from '@/api/axiosinterceptor';
-import ConfirmDialogs from './ConfirmDialogs.vue';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 import {planClsMapping, categoryColors} from '@/utils/PlanMappings'
 
 export default {

--- a/src/components/modal/TodoModal.vue
+++ b/src/components/modal/TodoModal.vue
@@ -38,11 +38,11 @@
 			</v-card-text>
 			<ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDelete" @disagree="cancleDelete" />
 			<v-card-actions>
+				<v-btn v-if="mode === 'edit'" color="primary" variant="outlined" @click="updateTodo" flat style="font-size: 15px; font-weight: 600;">수정</v-btn>
+				<v-btn v-if="mode === 'edit'" color="error" variant="outlined" @click="deleteTodo" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
 				<v-spacer></v-spacer>
-				<v-btn color="close" @click="closeModal">Close</v-btn>
-				<v-btn v-if="mode === 'add'" color="success" variant="text" @click="addTodo" flat>Save</v-btn>
-				<v-btn v-else-if="mode === 'edit'" color="success" variant="text" @click="updateTodo" flat>Update</v-btn>
-				<v-btn v-if="mode === 'edit'" color="error" variant="text" @click="deleteTodo" flat>Delete</v-btn>
+				<v-btn v-if="mode === 'add'" color="primary"@click="addTodo" flat style="font-size: 15px; font-weight: 600;">저장</v-btn>
+				<v-btn color="close" @click="closeModal" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
 			</v-card-actions>
 		</v-card>
 	</v-dialog>

--- a/src/components/modal/TodoModal.vue
+++ b/src/components/modal/TodoModal.vue
@@ -50,7 +50,7 @@
 
 <script>
 import '@/views/apps/calendar/calendar.css'
-import ConfirmDialogs from './ConfirmDialogs.vue';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 import api from '@/api/axiosinterceptor';
 
 export default {

--- a/src/components/modal/TodoModal.vue
+++ b/src/components/modal/TodoModal.vue
@@ -6,7 +6,7 @@
 				<v-form @submit.prevent="addTodo" lazy-validation>
 					<div>
 						<v-alert v-if="showAlert" type="warning" variant="tonal" class="warn-alert">
-							<h5 class="text-h6 text-capitalize">warning</h5>
+							<h5 class="text-h5 text-capitalize">warning</h5>
 							<div>{{ alertMessage }}</div>
 						</v-alert>
 					</div>

--- a/src/components/proposal/CreateProposal.vue
+++ b/src/components/proposal/CreateProposal.vue
@@ -4,6 +4,11 @@ import { useRouter } from 'vue-router';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import api from '@/api/axiosinterceptor';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 
 const router = useRouter();
 
@@ -72,7 +77,7 @@ const save = async () => {
     if (form.value) {
         const isValid = await form.value.validate();
         if (!isValid) {
-            alert('폼에 오류가 있습니다. 모든 필드를 올바르게 입력해주세요.');
+            triggerAlert('유효한 값을 입력해주세요.', 'error');
             return;
         }
     }
@@ -83,13 +88,14 @@ const save = async () => {
     try {
         const res = await api.post('/proposals', editedItem.value);
         if (res.status === 200 || res.status === 201) {
-            successAlert.value = true;
-            alertDialog.value = true;
-
-            setTimeout(() => router.push('/estimates'), 1500);
+            triggerAlert('제안이 추가되었습니다.', 'success', 2000,'/proposals');
+            // successAlert.value = true;
+            // alertDialog.value = true;
+            // setTimeout(() => router.push('/proposals'), 1500);
         }
     } catch (error) {
         console.error('등록 실패:', error);
+        triggerAlert('제안 등록에 실패했습니다.', 'success');
         errorAlert.value = true;
         alertDialog.value = true;
     } finally {
@@ -107,27 +113,7 @@ const errorAlert = ref(false);
 const warningAlert = ref(false);
 </script>
 <template>
-    <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
-        <v-card>
-            <v-card-text>
-                <v-alert v-if="successAlert" type="success" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Success</h5>
-                    <div>견적이 성공적으로 삭제되었습니다.</div>
-                </v-alert>
-                <v-alert v-if="errorAlert" type="error" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Error</h5>
-                    <div>견적 삭제에 실패했습니다. 다시 시도해주세요.</div>
-                </v-alert>
-                <v-alert v-if="warningAlert" type="warning" variant="tonal" class="mb-4">
-                    <h5 class="text-h6 text-capitalize">Warning</h5>
-                    <div>필수 항목을 입력해주세요.</div>
-                </v-alert>
-            </v-card-text>
-            <v-card-actions>
-                <v-btn color="primary" block @click="alertDialog = false" flat>Close</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div>
         <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
 

--- a/src/components/proposal/CreateProposal.vue
+++ b/src/components/proposal/CreateProposal.vue
@@ -7,8 +7,9 @@ import api from '@/api/axiosinterceptor';
 
 const router = useRouter();
 
+const page = ref({ title: '제안 등록' });
 const breadcrumbs = ref([
-    { text: '제안 리스트', disabled: false, href: '/proposals' },
+    { text: '제안 목록', disabled: false, href: '/proposals' },
     { text: '제안 등록', disabled: true, href: '/proposals/create' }
 ]);
 
@@ -128,7 +129,7 @@ const warningAlert = ref(false);
         </v-card>
     </v-dialog>
     <div>
-        <BaseBreadcrumb :title="''" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
+        <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
 
         <v-container>
             <UiParentCard title="">
@@ -161,20 +162,28 @@ const warningAlert = ref(false);
                     </v-col>
 
                     <!-- 영업기회 -->
-                    <v-col cols="12" sm="6">
-                        <v-text-field
+                    <v-row>
+                        <v-col class="ml-3" cols="5" md="2">
+                            <v-text-field
                             v-model="editedItem.leadName"
                             :items="leads"
                             item-text="name"
                             :rules="[(v) => !!v || '영업기회 버튼을 눌러 선택해주세요']"
                             readonly
                             outlined
-                        ></v-text-field>
+                            ></v-text-field>
+                        </v-col>
 
-                        <v-btn color="primary" variant="flat" class="mr-2 mdi text-h6 mdi-note-plus-outline" @click="openLeadModal"
-                            >영업기회 선택</v-btn
-                        >
-                    </v-col>
+                        <v-col class="mt-1" cols="3" md="3">
+                            <v-btn
+                            variant="flat"
+                            class="cus-btn"
+                            @click="openLeadModal"
+                            >
+                            <v-icon small class="mr-1">mdi-plus</v-icon>영업기회 가져오기
+                            </v-btn>
+                        </v-col>
+                    </v-row>
 
                     <v-dialog v-model="leadModal" max-width="600px">
                         <v-card>
@@ -236,12 +245,12 @@ const warningAlert = ref(false);
                     </v-col>
 
                     <v-row>
-                        <v-col cols="12" class="text-right">
-                            <v-btn color="primary" class="mr-3" flat type="submit" :disabled="!valid || loading">
+                        <v-col cols="12">
+                            <v-btn color="primary" flat type="submit" :disabled="!valid || loading">
                                 <v-progress-circular v-if="loading" indeterminate color="white" size="20"></v-progress-circular>
                                 저장
                             </v-btn>
-                            <v-btn color="error" class="mr-3" flat @click="cancel">취소</v-btn>
+                            <v-btn class="ml-2"  variant="outlined" color="primary" flat @click="cancel">목록으로 돌아가기</v-btn>
                         </v-col>
                     </v-row>
                 </v-form>
@@ -250,4 +259,18 @@ const warningAlert = ref(false);
     </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+
+.cus-btn {
+    background-color: #3f99f3;
+    color: white;
+    margin-left: 20px;
+    margin-bottom: 8px;
+    height: 30px;
+    line-height: 30px;
+    padding: 2px 10px 30px 5px;
+    border-radius: 8px;
+    transition: background-color 0.3s, color 0.3s;
+    box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/src/components/proposal/ProposalList.vue
+++ b/src/components/proposal/ProposalList.vue
@@ -5,11 +5,11 @@ import api from '@/api/axiosinterceptor';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 
-const page = ref({ title: '' });
-// const breadcrumbs = ref([
-//     { text: '영업관리', disabled: false, href: '#' },
-//     { text: '제안', disabled: true, href: '#' }
-// ]);
+const page = ref({ title: '제안 목록' });
+const breadcrumbs = ref([
+    { text: '영업관리', disabled: false, href: '#' },
+    { text: '제안', disabled: true, href: '#' }
+]);
 
 const dialogDelete = ref(false);
 const proposals = ref([]);
@@ -62,7 +62,7 @@ const headers = ref([
     { title: '', key: 'actions', sortable: false }
 ]);
 
-const formTitle = computed(() => (editedIndex.value === -1 ? '추가' : '수정'));
+const formTitle = computed(() => (editedIndex.value === -1 ? '제안 추가' : '제안 수정'));
 
 const router = useRouter();
 
@@ -233,7 +233,7 @@ const warningAlert = ref(false);
         </v-col>
 
         <v-col cols="12" md="10">
-            <UiParentCard title="">
+            <UiParentCard title="제안">
                 <v-data-table
                     :headers="headers"
                     :items="displayedProposals"
@@ -244,22 +244,30 @@ const warningAlert = ref(false);
                     <template v-slot:top>
                         <v-toolbar class="bg-lightsecondary" flat>
                             <v-toolbar-title></v-toolbar-title>
-                            <v-spacer></v-spacer>
-                            <v-col cols="auto">
-                                <v-btn color="primary" variant="flat" class="mr-2 mdi text-h6 mdi-plus-outline" @click="navigateToCreate"
-                                    >새로운 제안 등록</v-btn
-                                >
-                            </v-col>
+                                <v-row justify="end">
+                                    <v-col cols="auto">
+                                    <v-spacer></v-spacer>
+                                    <v-btn color="primary" variant="tonal" class="mr-2" @click="navigateToCreate">제안 생성</v-btn>
+                                </v-col>
+                            </v-row>
                         </v-toolbar>
                     </template>
 
                     <template v-slot:item.actions="{ item }">
-                        <v-icon color="info" size="small" class="me-2" @click="editItem(item)" role="button" aria-label="Edit Proposal">
-                            mdi-tooltip-edit
-                        </v-icon>
-                        <v-icon color="error" size="small" @click="deleteItem(item)" role="button" aria-label="Delete Proposal">
-                            mdi-delete-empty
-                        </v-icon>
+                        <EditIcon
+                            height="20"
+                            width="20"
+                            class="mr-2 text-primary cursor-pointer"
+                            size="small"
+                            @click="editItem(item)"
+                        />
+                        <TrashIcon
+                            height="20"
+                            width="20"
+                            class="text-error cursor-pointer"
+                            size="small"
+                            @click="deleteItem(item)"
+                        />
                     </template>
                 </v-data-table>
             </UiParentCard>
@@ -268,7 +276,7 @@ const warningAlert = ref(false);
 
     <v-dialog v-model="dialogEdit" max-width="500px">
         <v-card>
-            <v-card-title class="text-h5 text-center py-6">{{ formTitle }}</v-card-title>
+            <v-card-title>{{ formTitle }}</v-card-title>
             <v-card-text>
                 <v-form>
                     <v-text-field v-model="editedItem.leadName" label="영업기회명" disabled></v-text-field>
@@ -283,9 +291,8 @@ const warningAlert = ref(false);
             </v-card-text>
             <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn color="error" variant="flat" @click="closeEditDialog">Cancel</v-btn>
-                <v-btn color="success" variant="flat" @click="save">Save</v-btn>
-                <v-spacer></v-spacer>
+                <v-btn color="primary" variant="outlined" style="font-size: 15px; font-weight: 600;" @click="save">수정</v-btn>
+                <v-btn color="close" variant="plain" style="font-size: 15px; font-weight: 600;" @click="closeEditDialog">닫기</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/src/components/proposal/ProposalList.vue
+++ b/src/components/proposal/ProposalList.vue
@@ -6,6 +6,10 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 import { de } from 'date-fns/locale';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const showConfirmDialogs = ref(false); // 열림 상태 관리
 
@@ -15,9 +19,9 @@ const breadcrumbs = ref([
     { text: '제안', disabled: true, href: '#' }
 ]);
 
-const dialogDelete = ref(false);
+// const dialogDelete = ref(false);
 const proposals = ref([]);
-const leads = ref([]);
+// const leads = ref([]);
 const dialogEdit = ref(false);
 const editedIndex = ref(-1);
 
@@ -87,17 +91,19 @@ const submitProposalApi = async () => {
         const res = await api.post('/proposals', editedItem.value);
         console.log(res);
         if (res.status === 200) {
-            successAlert.value = true;
-            alertDialog.value = true;
-
-            setTimeout(() => router.push('proposals'), 1500);
+            triggerAlert('제안이 추가되었습니다.', 'success', 2000,'/proposals');
+            // successAlert.value = true;
+            // alertDialog.value = true;
+            // setTimeout(() => router.push('proposals'), 1500);
             await initialize();
             resetForm();
+            dialogEdit.value = false;
         }
     } catch (error) {
         console.error('등록 실패:', error);
-        errorAlert.value = true;
-        alertDialog.value = true;
+        triggerAlert('제안 수정에 실패했습니다.', 'error');
+        // errorAlert.value = true;
+        // alertDialog.value = true;
     }
 };
 
@@ -105,34 +111,37 @@ const updateProposalApi = async () => {
     try {
         const res = await api.patch(`/proposals/${editedItem.value.propNo}`, editedItem.value);
         if (res.status === 200) {
-            successAlert.value = true;
-            alertDialog.value = true;
-
-            setTimeout(() => router.push('proposals'), 1500);
-            await initialize();
-            resetForm();
+            triggerAlert('제안이 수정되었습니다.', 'success');
+            // successAlert.value = true;
+            // alertDialog.value = true;
+            // setTimeout(() => router.push('proposals'), 1500);
+            // await initialize();
+            // resetForm();
             dialogEdit.value = false;
         }
     } catch (error) {
         console.error('수정 실패:', error);
-        errorAlert.value = true;
-        alertDialog.value = true;
+        triggerAlert('제안 수정에 실패했습니다.', 'error');
+        // errorAlert.value = true;
+        // alertDialog.value = true;
     }
 };
 
 const deleteProposalApi = async () => {
     try {
         await api.delete(`/proposals/${editedItem.value.propNo}`);
-        successAlert.value = true;
-        alertDialog.value = true;
+        triggerAlert('제안이 삭제되었습니다.', 'success');
+        // successAlert.value = true;
+        // alertDialog.value = true;
         setTimeout(() => router.push('/proposals'), 1500);
         proposals.value.splice(editedIndex.value, 1);
         resetForm();
         router.push('/proposals');
     } catch (error) {
         console.error('삭제 실패:', error);
-        errorAlert.value = true;
-        alertDialog.value = true;
+        triggerAlert('제안 삭제에 실패했습니다.', 'error');
+        // errorAlert.value = true;
+        // alertDialog.value = true;
     } finally {
         showConfirmDialogs.value = false;
     }
@@ -197,6 +206,8 @@ const warningAlert = ref(false);
 
 <template>
     <ConfirmDialogs :dialog="showConfirmDialogs" @agree="deleteProposalApi" @disagree="() => (showConfirmDialogs = false)"/>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
+    
     <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
         <v-card>
             <v-card-text>

--- a/src/components/proposal/ProposalList.vue
+++ b/src/components/proposal/ProposalList.vue
@@ -4,6 +4,10 @@ import { useRouter } from 'vue-router';
 import api from '@/api/axiosinterceptor';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
+import { de } from 'date-fns/locale';
+
+const showConfirmDialogs = ref(false); // 열림 상태 관리
 
 const page = ref({ title: '제안 목록' });
 const breadcrumbs = ref([
@@ -129,6 +133,8 @@ const deleteProposalApi = async () => {
         console.error('삭제 실패:', error);
         errorAlert.value = true;
         alertDialog.value = true;
+    } finally {
+        showConfirmDialogs.value = false;
     }
     close();
 };
@@ -145,17 +151,20 @@ const createNewProposal = () => {
 
 const confirmDelete = async () => {
     await deleteProposalApi();
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 const deleteItem = (item) => {
     editedItem.value = { ...item };
     editedIndex.value = proposals.value.indexOf(item);
-    dialogDelete.value = true;
+    // dialogDelete.value = true;
+    showConfirmDialogs.value = true;
 };
 
 const closeDeleteDialog = () => {
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialogs.value = false;
 };
 
 const navigateToCreate = () => {
@@ -187,6 +196,7 @@ const warningAlert = ref(false);
 </script>
 
 <template>
+    <ConfirmDialogs :dialog="showConfirmDialogs" @agree="deleteProposalApi" @disagree="() => (showConfirmDialogs = false)"/>
     <v-dialog v-model="alertDialog" max-width="500" class="dialog-mw">
         <v-card>
             <v-card-text>
@@ -293,18 +303,6 @@ const warningAlert = ref(false);
                 <v-spacer></v-spacer>
                 <v-btn color="primary" variant="outlined" style="font-size: 15px; font-weight: 600;" @click="save">수정</v-btn>
                 <v-btn color="close" variant="plain" style="font-size: 15px; font-weight: 600;" @click="closeEditDialog">닫기</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
-
-    <v-dialog v-model="dialogDelete" max-width="500px">
-        <v-card>
-            <v-card-title class="text-h5 text-center py-6">선택한 제안을 정말 삭제하시겠습니까?</v-card-title>
-            <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="error" variant="flat" @click="closeDeleteDialog">삭제</v-btn>
-                <v-btn color="success" variant="flat" @click="confirmDelete">취소</v-btn>
-                <v-spacer></v-spacer>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/src/components/shared/AlertComponent.vue
+++ b/src/components/shared/AlertComponent.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-alert v-if="show" :type="type" class="alert" variant="tonal" >
+    <h5 class="text-h5 text-capitalize">{{ type === 'success' ? 'Success' : 'Warning' }}</h5>
+    <div>{{ message }}</div>
+  </v-alert>
+</template>
+
+<script>
+export default {
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+    type: {
+      type: String,
+      default: 'success',
+    },
+  },
+  watch: {
+    show(newVal) {
+      if (newVal) {
+        console.log("AlertComponent 활성화:", this.message);
+      } else {
+        console.log("AlertComponent 비활성화");
+      }
+    },
+  },
+};
+</script>
+<style scoped>
+.alert {
+  position: fixed;
+  top: 16%;
+  left: 90%;
+  transform: translateX(-50%);
+  z-index: 3000;
+  width: 100%;
+  max-width: 16%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  font-size: 1rem;
+}
+</style>

--- a/src/components/shared/ConfirmDialogs.vue
+++ b/src/components/shared/ConfirmDialogs.vue
@@ -27,8 +27,8 @@ const agreeDialog = () => {
         <v-card-text class="text-h5">정말 삭제하시겠습니까?</v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="green darken-1" variant="text" @click="closeDialog" flat>Disagree</v-btn>
-          <v-btn color="error" variant="text" @click="agreeDialog" flat>Agree</v-btn>
+          <v-btn color="error" variant="text" flat style="font-size: 16px; font-weight: 600;" @click="agreeDialog">삭제</v-btn>
+          <v-btn color="green darken-1" variant="text" flat style="font-size: 16px; font-weight: 600;" @click="closeDialog">닫기</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/shared/EditConfirmDialog.vue
+++ b/src/components/shared/EditConfirmDialog.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  dialog: Boolean, // 다이얼로그 표시 여부
+  message: {
+    type: String,
+    default: '이 항목을 수정하시겠습니까?'
+  },
+});
+
+const emit = defineEmits(['confirm', 'close', 'update:dialog']);
+
+const closeDialog = () => {
+  emit('close');
+  emit('update:dialog', false);
+};
+
+const confirmDialog = () => {
+  emit('confirm');
+  emit('update:dialog', false);
+};
+</script>
+
+<template>
+  <v-dialog v-bind:model-value="dialog" persistent max-width="400px">
+    <v-card class="pa-6">
+        <v-card-title class="text-h4 font-weight-bold d-flex align-center">
+        <v-icon size="40" class="mr-2" color="info">mdi-pencil</v-icon>
+        수정 확인
+      </v-card-title>
+      <v-card-text class="text-h5">{{ message }}</v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="info" variant="text" flat style="font-size: 16px; font-weight: 600;" @click="confirmDialog">수정</v-btn>
+        <v-btn color="grey darken-1" variant="text" flat style="font-size: 16px; font-weight: 600;" @click="closeDialog">닫기</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped>
+.dialog-mw {
+  max-width: 400px;
+}
+</style>

--- a/src/layouts/full/horizontal-sidebar/horizontalItems.ts
+++ b/src/layouts/full/horizontal-sidebar/horizontalItems.ts
@@ -98,7 +98,7 @@ const horizontalItems: menu[] = [
         to: '/sales/lead'
     },
     {
-        title: '캘린더',
+        title: '일정관리',
         icon: CalendarIcon,
         to: '/apps/calendar',
         children: [

--- a/src/scss/components/_VCard.scss
+++ b/src/scss/components/_VCard.scss
@@ -17,7 +17,7 @@
 }
 
 .v-card-title {
-    font-size: 1rem;
+    font-size: 1.1rem;
     font-weight: 700;
     line-height: 2rem;
     font-family: inherit;

--- a/src/utils/useAlert.js
+++ b/src/utils/useAlert.js
@@ -1,0 +1,30 @@
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+export function useAlert() {
+  const alertMessage = ref('');
+  const showAlert = ref(false);
+  const alertType = ref('');
+  const router = useRouter();
+
+  function triggerAlert(message, type = 'success', duration = 2000, redirectPath = null) {
+    alertMessage.value = message;
+    alertType.value = type;
+    showAlert.value = true;
+    console.log("triggerAlert 확인:", message, type, showAlert.value);
+
+    setTimeout(() => {
+      showAlert.value = false;
+      if (redirectPath) {
+        router.push(redirectPath);
+      }
+    }, duration);
+  }
+
+  return {
+    alertMessage,
+    showAlert,
+    alertType,
+    triggerAlert,
+  };
+}

--- a/src/views/apps/calendar/Calendar.vue
+++ b/src/views/apps/calendar/Calendar.vue
@@ -20,7 +20,7 @@ function allowedDates(val: unknown) {
 							<CalendarFilters />
 					</v-col>
 					<v-col cols="10">
-							<UiParentCard title="SalesBoost Calendar">
+							<UiParentCard title="캘린더">
 									<FullCalendar />
 							</UiParentCard>
 					</v-col>

--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -486,7 +486,7 @@ export default defineComponent({
       @close="closePlanModal" @add="addPlan" @delete="deletePlan" @update="updatePlan" @show-alert="handleAlert"/>
 
       <v-alert v-if="showSuccessAlert" type="success" variant="tonal" :class="['alert', alertType]">
-        <h5 class="text-h6 text-capitalize">Success</h5>
+        <h5 class="text-h5 text-capitalize">Success</h5>
           {{ alertMessage }}
       </v-alert>
     </div>
@@ -514,12 +514,13 @@ export default defineComponent({
 
 .alert {
   position: fixed;
-  top: 10%;
-  left: 70%;
+  top: 20%;
+  left: 90%;
   transform: translateX(-50%);
   z-index: 3000;
-  width: 90%;
-  max-width: 12%;
+  width: 100%;
+  max-width: 14%;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  font-size: 16px;
 }
 </style>

--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -465,7 +465,7 @@ export default defineComponent({
         <v-select
         v-model="selectedOption"
         :items="items"
-        label="Select"
+        label="생성"
         hide-details
         outlined
         class="select-item"

--- a/src/views/apps/calendar/act/Act.css
+++ b/src/views/apps/calendar/act/Act.css
@@ -10,8 +10,13 @@
 .alert {
   position: fixed;
   top: 10%;
-  right: 20px;
-  z-index: 999;
+  left: 90%;
+  transform: translateX(-50%);
+  z-index: 3000;
+  width: 100%;
+  max-width: 14%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  font-size: 1
 }
 
 .cus-btn {

--- a/src/views/apps/calendar/act/ActList.vue
+++ b/src/views/apps/calendar/act/ActList.vue
@@ -6,7 +6,7 @@ import UiParentCard from '@/components/shared/UiParentCard.vue';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import api from '@/api/axiosinterceptor';
 import { reverseActStatus, actStatus } from '@/utils/ActStatusMappings';
-import ConfirmDialogs from '@/components/modal/ConfirmDialogs.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 const page = ref({ title: '영업활동 목록' });
 const breadcrumbs = ref([

--- a/src/views/apps/calendar/act/ActList.vue
+++ b/src/views/apps/calendar/act/ActList.vue
@@ -7,6 +7,10 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import api from '@/api/axiosinterceptor';
 import { reverseActStatus, actStatus } from '@/utils/ActStatusMappings';
 import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
 const page = ref({ title: '영업활동 목록' });
 const breadcrumbs = ref([
@@ -38,9 +42,7 @@ const editedItem = ref(null);
 
 async function initialize() {
 try {
-  console.log('초기화!')
   const response = await api.get('/acts');
-  console.log('response!',response)
   actList.value = response.data.result;
   } catch (error) {
   console.error(error);
@@ -48,22 +50,18 @@ try {
 }
 
 function deleteItem(item) {
-  console.log('editedItem.value.actNo',item.actNo)
   editedItem.value = item;
-  console.log('editedItem.value',editedItem.value)
   dialogDelete.value = true;
-  console.log('dialogDelete.value',dialogDelete.value)
 }
 
 async function confirmDelete() {
-  console.log('confirmDelete 함수 호출됨');
-  console.log('editedItem.value.actNo2', editedItem.value);
   if (editedItem.value) {
     try {
       await api.delete(`/acts/${editedItem.value.actNo}`);
       actList.value = actList.value.filter(act => act.actNo !== editedItem.value.actNo);
       dialogDelete.value = false;
       editedItem.value = null;
+      triggerAlert('삭제가 완료되었습니다.', 'success', 2000, '/apps/act/list');
     } catch (error) {
       console.error('삭제 실패:', error);
     }
@@ -100,6 +98,7 @@ onMounted(() => {
 </script>
 <template>
   <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
+  <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
   <v-row>
     <v-col cols="12">
       <UiParentCard title="영업활동">
@@ -176,3 +175,17 @@ onMounted(() => {
     </v-col>
   </v-row>
 </template>
+
+<style>
+
+.alert {
+  position: fixed;
+  top: 16%;
+  left: 90%;
+  transform: translateX(-50%);
+  z-index: 3000;
+  width: 100%;
+  max-width: 14%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/src/views/apps/calendar/act/ActList.vue
+++ b/src/views/apps/calendar/act/ActList.vue
@@ -11,9 +11,9 @@ import ConfirmDialogs from '@/components/modal/ConfirmDialogs.vue';
 const page = ref({ title: '영업활동 목록' });
 const breadcrumbs = ref([
 {
-	text: '영업도구',
+	text: '일정관리',
 	disabled: false,
-	to: '/'
+	to: '#'
 },
 {
 	text: '영업활동',
@@ -102,7 +102,7 @@ onMounted(() => {
   <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
   <v-row>
     <v-col cols="12">
-      <UiParentCard title="Act List">
+      <UiParentCard title="영업활동">
         <v-data-table
           class="rounded-md datatabels actlist"
           :headers="headers"
@@ -163,12 +163,12 @@ onMounted(() => {
                 class="mb-md-0 mb-3"
               />
               <v-spacer></v-spacer>
-              <v-btn color="primary" @click="goToAddAct">Add New</v-btn>
+              <v-btn color="primary" variant="tonal" @click="goToAddAct">영업활동 생성</v-btn>
             </v-toolbar>
           </template>
 
           <template v-slot:no-data>
-            <v-btn color="primary" @click="resetSearch"> Reset </v-btn>
+            <v-btn color="primary" variant="tonal" @click="resetSearch"> 초기화 </v-btn>
           </template>
         </v-data-table>
         <ConfirmDialogs :dialog="dialogDelete" @agree="confirmDelete" @disagree="cancleDelete" />

--- a/src/views/apps/calendar/act/ActView.vue
+++ b/src/views/apps/calendar/act/ActView.vue
@@ -139,7 +139,7 @@ import { ref, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import api from '@/api/axiosinterceptor';
 import { actStatus } from '@/utils/ActStatusMappings';
-import ConfirmDialogs from '@/components/modal/ConfirmDialogs.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 import './Act.css'
 
 export default {

--- a/src/views/apps/calendar/act/ActView.vue
+++ b/src/views/apps/calendar/act/ActView.vue
@@ -1,11 +1,11 @@
 <template>
     <div>
       <v-alert v-if="showSuccessAlert" type="success" variant="tonal" class="alert">
-        <h5 class="text-h6 text-capitalize">Success</h5>
+        <h5 class="text-h5 text-capitalize">Success</h5>
         <div>{{ alertMessage }}</div>
       </v-alert>
       <v-alert v-else-if="showAlert" type="warning" variant="tonal" class="alert">
-        <h5 class="text-h6 text-capitalize">Warning</h5>
+        <h5 class="text-h5 text-capitalize">Warning</h5>
         <div>{{ alertMessage }}</div>
       </v-alert>
     </div>

--- a/src/views/apps/contract/ContractDetailView.vue
+++ b/src/views/apps/contract/ContractDetailView.vue
@@ -2,9 +2,10 @@
 <script>
 import api from '@/api/axiosinterceptor';
 import ContractModal from './ContractModal.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 export default {
-    components: { ContractModal },
+    components: { ContractModal, ConfirmDialogs },
     data() {
         return {
             contracts: [],
@@ -16,6 +17,8 @@ export default {
                 { title: '', key: 'action', sortable: false },
             ],
             showModal: false,
+            showConfirmDialogs: false,
+            selectedContractNo: null, // 삭제할 계약 번호 저장해놓고 공유하기
             editedContract: {
                 contractNo: null,
                 name: '',
@@ -53,17 +56,21 @@ export default {
                 console.error('계약 목록을 가져오는 데 실패했습니다:', error);
             }
         },
-        async deleteContract(contractNo) {
-            if (confirm('정말로 이 계약을 삭제하시겠습니까?')) {
-                try {
-                    await api.delete(`/contract/${contractNo}`);
-                    this.fetchContracts();
-                    alert('계약이 삭제되었습니다.');
-                } catch (error) {
-                    console.error('계약 삭제에 실패했습니다:', error);
-                    alert('계약 삭제에 실패했습니다.');
-                }
+        async confirmDeleteContract() {
+            try {
+                await api.delete(`/contract/${this.selectedContractNo}`);
+                this.fetchContracts();
+                alert('계약이 삭제되었습니다.');
+            } catch (error) {
+                console.error('계약 삭제에 실패했습니다:', error);
+                alert('계약 삭제에 실패했습니다.');
+            } finally {
+                this.showConfirmDialogs = false;
             }
+        },
+        async deleteContract(contractNo) {
+            this.selectedContractNo = contractNo;
+            this.showConfirmDialogs = true;
         },
         editContract(contract) {
             this.editedContract = { ...contract };
@@ -149,6 +156,8 @@ export default {
                 <v-alert type="info">데이터가 없습니다.</v-alert>
             </template>
         </v-data-table>
+
+        <ConfirmDialogs :dialog="showConfirmDialogs" @agree="confirmDeleteContract" @disagree="showConfirmDialogs = false" />
 
         <ContractModal
             v-model="showModal"

--- a/src/views/apps/contract/ContractDetailView.vue
+++ b/src/views/apps/contract/ContractDetailView.vue
@@ -13,7 +13,7 @@ export default {
                 { title: '계약 이름', key: 'name' },
                 { title: '시작 날짜', key: 'startDate' },
                 { title: '종료 날짜', key: 'endDate' },
-                { title: '추가 작업', key: 'action', sortable: false },
+                { title: '', key: 'action', sortable: false },
             ],
             showModal: false,
             editedContract: {
@@ -120,16 +120,29 @@ export default {
         <v-row>
             <v-col><div >총 견적 개수: {{ contracts.length }}개</div> </v-col>
             <v-col cols="12" lg="12" md="6" class="text-right">
-                <v-btn color="primary" @click="openModal" flat class="ml-auto">
-                    <v-icon class="mr-2">mdi-account-multiple-plus</v-icon>계약 추가
+                <v-btn color="primary" variant="tonal"  @click="openModal" flat class="ml-auto"> 계약 생성
                 </v-btn>
             </v-col>
         </v-row>
         <v-data-table :headers="headers" :items="contracts" class="elevation-0">
 
             <template v-slot:item.action="{ item }">
-                <v-btn @click="editContract(item)" style="color: slateblue">수정</v-btn>
-                <v-btn @click="deleteContract(item.contractNo)" style="color: crimson">삭제</v-btn>
+                <div class="d-flex gap-2">
+                <EditIcon
+                    height="20"
+                    width="20"
+                    class="text-primary cursor-pointer"
+                    size="small"
+                    @click="editContract(item)"
+                />
+                <TrashIcon
+                    height="20"
+                    width="20"
+                    class="text-error cursor-pointer"
+                    size="small"
+                    @click="deleteContract(item.contractNo)"
+                />
+                </div>
             </template>
 
             <template v-slot:no-data>

--- a/src/views/apps/contract/ContractDetailView.vue
+++ b/src/views/apps/contract/ContractDetailView.vue
@@ -3,9 +3,12 @@
 import api from '@/api/axiosinterceptor';
 import ContractModal from './ContractModal.vue';
 import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
 
 export default {
-    components: { ContractModal, ConfirmDialogs },
+    components: { ContractModal, ConfirmDialogs,AlertComponent },
     data() {
         return {
             contracts: [],
@@ -44,6 +47,10 @@ export default {
             search: '',
         };
     },
+    setup() {
+        const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+        return { alertMessage, alertType, showAlert, triggerAlert };
+    },
     mounted() {
         this.fetchContracts();
     },
@@ -59,11 +66,12 @@ export default {
         async confirmDeleteContract() {
             try {
                 await api.delete(`/contract/${this.selectedContractNo}`);
-                this.fetchContracts();
-                alert('계약이 삭제되었습니다.');
+                this.fetchContracts();        
+                this.triggerAlert('계약이 삭제되었습니다.', 'success', 2000);
+
             } catch (error) {
                 console.error('계약 삭제에 실패했습니다:', error);
-                alert('계약 삭제에 실패했습니다.');
+                this.triggerAlert('계약 삭제에 실패했습니다.', 'error', 2000);
             } finally {
                 this.showConfirmDialogs = false;
             }
@@ -113,8 +121,10 @@ export default {
                 }
                 this.fetchContracts(); 
                 this.closeModal();
+                this.triggerAlert('계약이 등록되었습니다.', 'success', 2000);
             } catch (error) {
                 console.error('계약 저장에 실패했습니다:', error);
+                this.triggerAlert('계약 저장에 실패했습니다.', 'error', 2000);
             }
         },
     },
@@ -123,6 +133,7 @@ export default {
 
 
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div>
         <v-row>
             <v-col><div >총 견적 개수: {{ contracts.length }}개</div> </v-col>

--- a/src/views/apps/contract/ContractModal.vue
+++ b/src/views/apps/contract/ContractModal.vue
@@ -28,8 +28,8 @@
         </v-form>
       </v-card-text>
       <v-card-actions>
-        <v-btn @click="saveContract">저장</v-btn>
-        <v-btn @click="handleClose">취소</v-btn>
+        <v-btn color="primary" variant="outlined" @click="saveContract" flat style="font-size: 15px; font-weight: 600;">저장</v-btn>
+        <v-btn color="close" @click="handleClose" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/views/apps/contract/ContractView.vue
+++ b/src/views/apps/contract/ContractView.vue
@@ -4,13 +4,25 @@ import { ref } from 'vue';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import ContractDetailView from './ContractDetailView.vue';
 // theme breadcrumb
-const page = ref({ title: '계약 정보' });
+const page = ref({ title: '계약 목록' });
+const breadcrumbs = ref([
+{
+	text: '영업관리',
+	disabled: false,
+	to: '#'
+},
+{
+	text: '계약',
+	disabled: true,
+	to: ''
+	},
+]);
 
 
 </script>
 
 <template>
-    <BaseBreadcrumb :title="page.title" ></BaseBreadcrumb>
+  <BaseBreadcrumb :title="page.title" class="" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
     <v-card elevation="10">
         <v-card-text>
             <ContractDetailView/>

--- a/src/views/apps/customer/Customer.vue
+++ b/src/views/apps/customer/Customer.vue
@@ -8,7 +8,7 @@
         <div class="customer_container">
             <div class="header">
                 <div class="result_count">(검색결과: {{ dataSize }}건)</div>   
-                <v-btn variant="tonal" color="primary" to="/sales/customer-add">고객 추가</v-btn>
+                <v-btn variant="tonal" color="primary" to="/sales/customer-add">고객 생성</v-btn>
             </div>
             <hr  class="divider"></hr>
                 <CustomerCard :customers="customers"/>

--- a/src/views/apps/department/Department.vue
+++ b/src/views/apps/department/Department.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <v-card>
             <v-card-title class="custom-card-title">
-                Department
+                부서 관리
             </v-card-title>
             <v-row class="pa-4" justify="space-between">
                 <v-col cols="12" md="3">
@@ -29,12 +29,12 @@
                             <v-card>
                                 <v-row class="text-right">
                                     <v-col class="text-sm-left">
-                                        <span class="font-weight-black custom-margin">정보</span>
+                                        <span class="font-weight-black custom-margin">부서 정보</span>
                                     </v-col>
                                     <v-col>
-                                        <v-btn color="primary" @click="addItem">add</v-btn>
-                                        <v-btn color="primary" @click="updateItem(selected)" :disabled="!selected">Update</v-btn>
-                                        <v-btn color="primary" @click.stop="deleteItem(selected)" :disabled="!selected">Delete</v-btn>
+                                        <v-btn color="primary" variant="tonal" @click="addItem" :disabled="selected">생성</v-btn>
+                                        <v-btn color="primary" variant="tonal" @click="updateItem(selected)" :disabled="!selected">수정</v-btn>
+                                        <v-btn class="mr-3" color="error" variant="tonal" @click.stop="deleteItem(selected)" :disabled="!selected">삭제</v-btn>
                                     </v-col>
                                 </v-row>
                                 <v-card-text>
@@ -75,7 +75,7 @@
 
     <v-dialog v-model="dialog" max-width="500px">
         <v-card>
-            <v-card-title class="text-h5">{{ isEdit ? 'Update Department' : 'Add Department' }}</v-card-title>
+            <v-card-title class="text-h5">{{ isEdit ? '부서 정보 수정' : '부서 생성' }}</v-card-title>
             <v-card-text>
                 <v-container>
                     <v-row>
@@ -124,10 +124,10 @@
                 </v-container>
             </v-card-text>
             <v-card-actions>
-                <v-btn :disabled="!formValid" color="primary" @click="isEdit ? updateDepartment() : saveDepartment()">
-                    Save
+                <v-btn color="primary" variant="plain" flat style="font-size: 15px; font-weight: 600;" :disabled="!formValid" @click="isEdit ? updateDepartment() : saveDepartment()">
+                    저장
                 </v-btn>
-                <v-btn @click="dialog = false">Cancel</v-btn>
+                <v-btn color="close" flat style="font-size: 15px; font-weight: 600;" @click="dialog = false">닫기</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>
@@ -179,7 +179,7 @@ export default {
         items() {
             return [
                 {
-                    name: 'Departments',
+                    name: '부서',
                     children: this.departments,
                 },
             ];

--- a/src/views/apps/department/Department.vue
+++ b/src/views/apps/department/Department.vue
@@ -132,28 +132,21 @@
         </v-card>
     </v-dialog>
 
+    <ConfirmDialogs :dialog.sync="showConfirmDialog" @agree="confirmDelete" @disagree="showConfirmDialog = false" />
 
-    <v-dialog v-model="dialogDelete" max-width="400px">
-        <v-card>
-            <v-card-title class="text-h5">Delete Confirmation</v-card-title>
-            <v-card-text>Are you sure you want to delete this item?</v-card-text>
-            <v-card-actions>
-                <v-btn color="error" @click="confirmDelete">Delete</v-btn>
-                <v-btn @click="dialogDelete = false">Cancel</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
 </template>
 
 <script>
 import { VTreeview } from 'vuetify/labs/VTreeview';
 import api from '@/api/axiosinterceptor';
 import FilterCard from '@/components/customer/FilterCard.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 export default {
     components: {
         VTreeview,
         FilterCard,
+        ConfirmDialogs,
     },
 
     data: () => ({
@@ -162,10 +155,11 @@ export default {
         departments: [],
         departmentNames: [],
         userNames: [],
-        dialogDelete: false,
+        // dialogDelete: false,
         dialog: false,
         formValid: false,
         isEdit: false,
+        showConfirmDialog: false,
         department: {
             deptCode : '',
             deptName : '',
@@ -257,7 +251,7 @@ export default {
         
         async confirmDelete() {
             try {
-                this.dialogDelete = false;
+                // this.dialogDelete = false;
                 const apiUrl = `/admin/departments/${this.selected.no}`;
                 const response = await api.delete(apiUrl);
                 console.log('Delete successful:', response.data);
@@ -266,6 +260,8 @@ export default {
                 await this.fetchDepartments();
             } catch (error) {
                 console.error('Error deleting item:', error.message || error);
+            }finally{
+                this.showConfirmDialog = false;
             }
         },
 
@@ -320,7 +316,8 @@ export default {
 
         deleteItem(item) {
             this.selectedItem = item;
-            this.dialogDelete = true;
+            // this.dialogDelete = true;
+            this.showConfirmDialog = true;
         },
 
         addItem(){

--- a/src/views/apps/department/Department.vue
+++ b/src/views/apps/department/Department.vue
@@ -1,4 +1,6 @@
 <template>
+
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div class="container">
         <v-card>
             <v-card-title class="custom-card-title">
@@ -124,7 +126,7 @@
                 </v-container>
             </v-card-text>
             <v-card-actions>
-                <v-btn color="primary" variant="plain" flat style="font-size: 15px; font-weight: 600;" :disabled="!formValid" @click="isEdit ? updateDepartment() : saveDepartment()">
+                <v-btn color="primary" variant="plain" flat style="font-size: 15px; font-weight: 600;" @click="isEdit ? updateDepartment() : saveDepartment()">
                     저장
                 </v-btn>
                 <v-btn color="close" flat style="font-size: 15px; font-weight: 600;" @click="dialog = false">닫기</v-btn>
@@ -141,12 +143,15 @@ import { VTreeview } from 'vuetify/labs/VTreeview';
 import api from '@/api/axiosinterceptor';
 import FilterCard from '@/components/customer/FilterCard.vue';
 import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
 
 export default {
     components: {
         VTreeview,
         FilterCard,
         ConfirmDialogs,
+        AlertComponent
     },
 
     data: () => ({
@@ -255,6 +260,7 @@ export default {
                 const apiUrl = `/admin/departments/${this.selected.no}`;
                 const response = await api.delete(apiUrl);
                 console.log('Delete successful:', response.data);
+                this.triggerAlert('부서가 삭제되었습니다.', 'success', 2000);
 
                 this.clearForm();
                 await this.fetchDepartments();
@@ -269,6 +275,7 @@ export default {
             try {
                 const response = await api.post('/admin/departments', this.department);
                 console.log('부서 저장 성공:', response.data);
+                this.triggerAlert('부서를 등록하였습니다.', 'success', 2000);
 
                 this.clearForm();
                 this.dialog = false;
@@ -276,6 +283,7 @@ export default {
                 await this.fetchDepartments();
             } catch (error) {
                 console.error('부서 저장 중 오류 발생:', error);
+                this.triggerAlert('부서 삭제에 실패했습니다.', 'error', 2000);
             }
         },
 
@@ -292,6 +300,7 @@ export default {
                 const apiUrl = `/admin/departments/${this.selected.no}`;
                 const response = await api.patch(apiUrl, this.department);
                 console.log('부서 업데이트 성공:', response.data);
+                this.triggerAlert('부서 정보를 수정하였습니다.', 'success', 2000);
 
                 this.clearForm();
                 await this.fetchDepartments();
@@ -326,6 +335,10 @@ export default {
             this.dialog = true;
         },
 
+    },
+    setup() {
+        const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+        return { alertMessage, alertType, showAlert, triggerAlert };
     },
 
     mounted() {

--- a/src/views/apps/lead/Lead.vue
+++ b/src/views/apps/lead/Lead.vue
@@ -149,7 +149,7 @@ onMounted(() => {
                         </v-col>
                         <v-spacer></v-spacer>
                         <v-col cols="auto">
-                            <v-btn color="primary" to="/sales/lead/new">영업기회 생성</v-btn>
+                            <v-btn variant="tonal" color="primary" to="/sales/lead/new" class="mb-3">영업기회 생성</v-btn>
                         </v-col>
                     </v-row>
                     <v-divider :thickness="3" class="border-opacity-50 thick-divider" color="info"></v-divider>

--- a/src/views/apps/pCustomer/pCustomer.vue
+++ b/src/views/apps/pCustomer/pCustomer.vue
@@ -8,7 +8,7 @@
         <div class="customer_container">
             <div class="header">
                 <div class="result_count">(검색결과: {{ dataSize }}건)</div>   
-                <v-btn variant="tonal" color="primary" to="/sales/prospect/add">잠재고객 추가</v-btn>
+                <v-btn variant="tonal" color="primary" to="/sales/prospect/add">잠재고객 생성</v-btn>
             </div>
          
             <hr  class="divider"></hr>

--- a/src/views/apps/process/Process.vue
+++ b/src/views/apps/process/Process.vue
@@ -4,6 +4,11 @@ import api from '@/api/axiosinterceptor';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 const headers1 = ref([
     { title: '서브 프로세스', align: 'start', key: 'subProcessName' },
     { title: '진행 단계', align: 'start', key: 'progressStep' },
@@ -77,7 +82,8 @@ function addParentProcess() {
 // 하위 프로세스 추가 함수
 function addSubProcess() {
     if (!selectedProcess.value) {
-        alert('상위 프로세스를 선택한 후 하위 프로세스를 추가하세요.');
+        // alert('상위 프로세스를 선택한 후 하위 프로세스를 추가하세요.');
+        triggerAlert('상위 프로세스를 선택한 후 하위 프로세스를 추가하세요.', 'warning', 2000);
         return;
     }
 
@@ -101,14 +107,17 @@ async function saveParentProcess() {
         if (dialogMode.value === 'add-parent') {
             const response = await api.post(`/admin/processes`, editedItem.value);
             console.log('Parent process 추가 성공:', response.data);
+            triggerAlert('프로세스가 등록되었습니다.', 'success', 2000);
         } else if (dialogMode.value === 'edit-parent') {
             const response = await api.patch(`/admin/processes/${editedItem.value.processNo}`, editedItem.value);
             console.log('Parent process 수정 성공:', response.data);
+            triggerAlert('프로세스가 수정되었습니다.', 'success', 2000);
         }
         dialog.value = false;
         await fetchProcesses();
     } catch (error) {
         console.error('상위 프로세스 저장 중 오류:', error.message || error);
+        triggerAlert('프로세스 등록에 실패했습니다.', 'error', 2000);
     }
 }
 
@@ -119,10 +128,12 @@ async function saveSubProcess() {
         if (dialogMode.value === 'add-sub') {
             const response = await api.post(`/admin/subprocesses`, editedItem.value);
             console.log('Subprocess 추가 성공:', response.data);
+            triggerAlert('하위 프로세스가 등록되었습니다.', 'success', 2000);
         } else if (dialogMode.value === 'edit-sub') {
             console.log("hihi");
             const response = await api.patch(`/admin/subprocesses/${editedItem.value.subProcessNo}`, editedItem.value);
             console.log('Subprocess 수정 성공:', response.data);
+            triggerAlert('하위 프로세스가 수정되었습니다.', 'success', 2000);
         }
 
         dialog.value = false;
@@ -131,6 +142,7 @@ async function saveSubProcess() {
         fetchProcesses();
     } catch (error) {
         console.error('하위 프로세스 저장 중 오류:', error.message || error);
+        triggerAlert('하위 프로세스 등록에 실패했습니다.', 'error', 2000);
     }
 }
 
@@ -166,6 +178,7 @@ async function confirmDelete() {
             : `/admin/subprocesses/${editedItem.value.subProcessNo}`;
         const response = await api.delete(apiUrl);
         console.log('Delete successful:', response.data);
+        triggerAlert('프로세스가 삭제되었습니다.', 'success', 2000);
 
         editedItem.value = null;
 
@@ -176,6 +189,7 @@ async function confirmDelete() {
         }
     } catch (error) {
         console.error('Error deleting item:', error.message || error);
+        triggerAlert('프로세스 삭제에 실패했습니다.', 'error', 2000);
     }
 }
 
@@ -194,6 +208,7 @@ onMounted(() => {
 </script>
 
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <v-row>
         <v-col cols="12">
             <UiParentCard title="프로세스 관리">

--- a/src/views/apps/process/Process.vue
+++ b/src/views/apps/process/Process.vue
@@ -9,7 +9,7 @@ const headers1 = ref([
     { title: '성공 확률(%)', align: 'start', key: 'successRate' },
     { title: '내용', align: 'start', key: 'description' },
     { title: '예상 소요 기간(일)', align: 'start', key: 'expectedDuration' },
-    { title: 'Actions', align: 'start' },
+    { title: '', align: 'start' },
 ]);
 
 const headers2 = ref([
@@ -17,7 +17,7 @@ const headers2 = ref([
     { title: '기본 프로세스', key: 'isDefault' },
     { title: '내용', key: 'description' },
     { title: '예상 소요기간', key: 'expectedDuration' },
-    { title: 'Actions', align: 'start' },
+    { title: '', align: 'start' },
 ]);
 
 const dialog = ref(false);
@@ -192,7 +192,7 @@ onMounted(() => {
 <template>
     <v-row>
         <v-col cols="12">
-            <UiParentCard title="Sales Process">
+            <UiParentCard title="프로세스 관리">
                 <v-data-table
                     class="border rounded-md"
                     :headers="headers2"
@@ -211,20 +211,28 @@ onMounted(() => {
                             <td>{{ item.description }}</td>
                             <td>{{ item.expectedDuration }}</td>
                             <td>
-                                <v-icon color="info" size="small" class="me-2" @click.stop="editItem(item, 'parent')">
-                                    mdi-pencil
-                                </v-icon>
-                                <v-icon color="error" size="small" @click.stop="deleteItem(item, 'parent')">
-                                    mdi-delete
-                                </v-icon>
+                                <EditIcon
+                                    height="20"
+                                    width="20"
+                                    class="mr-2 text-primary cursor-pointer"
+                                    size="small"
+                                    @click.stop="editItem(item, 'parent')"
+                                />
+                                <TrashIcon
+                                    height="20"
+                                    width="20"
+                                    class="text-error cursor-pointer"
+                                    size="small"
+                                    @click.stop="deleteItem(item, 'parent')"
+                                />
                             </td>
                         </tr>
                     </template>
                     <template v-slot:top>
                         <v-toolbar class="bg-lightsecondary" flat>
-                            <v-toolbar-title>Process</v-toolbar-title>
+                            <v-toolbar-title>프로세스</v-toolbar-title>
                             <v-spacer></v-spacer>
-                            <v-btn color="primary" variant="flat" dark @click="addParentProcess">Add New Parent Process</v-btn>
+                            <v-btn class="mr-3" color="primary" variant="tonal" dark @click="addParentProcess">프로세스 생성</v-btn>
                         </v-toolbar>
                     </template>
                 </v-data-table>
@@ -242,20 +250,28 @@ onMounted(() => {
                             <td>{{ item.description }}</td>
                             <td>{{ item.expectedDuration }}</td>
                             <td>
-                                <v-icon color="info" size="small" class="me-2" @click.stop="editItem(item, 'sub')">
-                                    mdi-pencil
-                                </v-icon>
-                                <v-icon color="error" size="small" @click.stop="deleteItem(item, 'sub')">
-                                    mdi-delete
-                                </v-icon>
+                                <EditIcon
+                                    height="20"
+                                    width="20"
+                                    class="mr-2 text-primary cursor-pointer"
+                                    size="small" 
+                                    @click.stop="editItem(item, 'sub')"
+                                />
+                                <TrashIcon
+                                    height="20"
+                                    width="20"
+                                    class="text-error cursor-pointer"
+                                    size="small"
+                                    @click.stop="deleteItem(item, 'sub')"
+                                />
                             </td>
                         </tr>
                     </template>
                     <template v-slot:top>
                         <v-toolbar class="bg-lightsecondary" flat>
-                            <v-toolbar-title>Sub Process</v-toolbar-title>
+                            <v-toolbar-title>하위 프로세스</v-toolbar-title>
                             <v-spacer></v-spacer>
-                            <v-btn color="primary" variant="flat" dark @click="addSubProcess">Add New Sub Process</v-btn>
+                            <v-btn class="mr-3" color="primary" variant="tonal" dark @click="addSubProcess">하위 프로세스 생성</v-btn>
                         </v-toolbar>
                     </template>
                 </v-data-table>
@@ -266,7 +282,7 @@ onMounted(() => {
     <v-dialog v-model="dialog" max-width="500px">
         <v-card>
             <v-card-title class="text-h5">
-                {{ dialogMode.includes('edit') ? 'Edit Item' : dialogMode === 'add-parent' ? 'Add Parent Process' : 'Add Sub Process' }}
+                {{ dialogMode.includes('edit') ? '프로세스 수정' : dialogMode === 'add-parent' ? '프로세스 등록' : '하위 프로세스 등록' }}
             </v-card-title>
 
             <v-card-text>
@@ -302,9 +318,9 @@ onMounted(() => {
                 </v-container>
             </v-card-text>
             <v-card-actions>
-                <v-btn v-if="dialogMode === 'add-parent' || dialogMode === 'edit-parent'" color="primary" @click="saveParentProcess" :disabled="!formValid">Save Parent Process</v-btn>
-                <v-btn v-else color="primary" @click="saveSubProcess" :disabled="!formValid">Save Sub Process</v-btn>
-                <v-btn @click="dialog = false">Cancel</v-btn>
+                <v-btn v-if="dialogMode === 'add-parent' || dialogMode === 'edit-parent'" color="primary" flat style="font-size: 15px; font-weight: 600;" @click="saveParentProcess" :disabled="!formValid">저장</v-btn>
+                <v-btn v-else color="primary" flat style="font-size: 15px; font-weight: 600;" @click="saveSubProcess" :disabled="!formValid">저장</v-btn>
+                <v-btn flat style="font-size: 15px; font-weight: 600;" @click="dialog = false">닫기</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>
@@ -315,7 +331,7 @@ onMounted(() => {
             <v-card-text>Are you sure you want to delete this item?</v-card-text>
             <v-card-actions>
                 <v-btn color="error" @click="confirmDelete">Delete</v-btn>
-                <v-btn @click="dialogDelete = false">Cancel</v-btn>
+                <v-btn  flat style="font-size: 15px; font-weight: 600;" @click="dialogDelete = false">Cancel</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/src/views/apps/process/Process.vue
+++ b/src/views/apps/process/Process.vue
@@ -2,6 +2,7 @@
 import { ref, watch, onMounted } from 'vue';
 import api from '@/api/axiosinterceptor';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 const headers1 = ref([
     { title: '서브 프로세스', align: 'start', key: 'subProcessName' },
@@ -21,7 +22,8 @@ const headers2 = ref([
 ]);
 
 const dialog = ref(false);
-const dialogDelete = ref(false);
+// const dialogDelete = ref(false);
+const showConfirmDialog = ref(false);
 const processes = ref([]);
 const subProcesses = ref([]);
 const editedItem = ref(null);
@@ -137,7 +139,8 @@ async function saveSubProcess() {
 function deleteItem(item, type) {
     editedItem.value = { ...item };
     dialogMode.value = `delete-${type}`;
-    dialogDelete.value = true;
+    // dialogDelete.value = true;
+    showConfirmDialog.value = true; 
 }
 
 // 폼 유효성 검사 함수
@@ -156,7 +159,8 @@ function validateForm() {
 // 항목 삭제 확정
 async function confirmDelete() {
     try {
-        dialogDelete.value = false;
+        // dialogDelete.value = false;
+        showConfirmDialog.value = false;
         const apiUrl = dialogMode.value.includes('parent')
             ? `/admin/processes/${editedItem.value.processNo}`
             : `/admin/subprocesses/${editedItem.value.subProcessNo}`;
@@ -325,14 +329,6 @@ onMounted(() => {
         </v-card>
     </v-dialog>
 
-    <v-dialog v-model="dialogDelete" max-width="400px">
-        <v-card>
-            <v-card-title class="text-h5">Delete Confirmation</v-card-title>
-            <v-card-text>Are you sure you want to delete this item?</v-card-text>
-            <v-card-actions>
-                <v-btn color="error" @click="confirmDelete">Delete</v-btn>
-                <v-btn  flat style="font-size: 15px; font-weight: 600;" @click="dialogDelete = false">Cancel</v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    <ConfirmDialogs :dialog="showConfirmDialog" @agree="confirmDelete" @disagree="showConfirmDialog = false" />
+
 </template>

--- a/src/views/apps/product/Product.vue
+++ b/src/views/apps/product/Product.vue
@@ -22,7 +22,7 @@ const headers = ref([
     { title: '원가', key: 'supplyPrice' },
     { title: '세율', key: 'taxRate' },
     { title: '가격', key: 'price' },
-    { title: 'Actions', key: 'actions'},
+    { title: '', key: 'actions'},
 ]);
 
 const items = ref([]);
@@ -109,7 +109,7 @@ function initialize() {
 
 }
 
-const formTitle = computed(() => (editedIndex.value === -1 ? 'New Item' : 'Edit Item'));
+const formTitle = computed(() => (editedIndex.value === -1 ? '제품 등록' : '제품 수정'));
 
 function editItem(item) {
     editedIndex.value = items.value.indexOf(item);
@@ -179,7 +179,7 @@ initialize();
 </script>
 
 <template>
-    <UiParentCard title="Products Table">
+    <UiParentCard title="관리 제품 목록">
         <v-row class="mb-5">
             <v-col cols="4" sm="4">
                 <v-text-field v-model="searchProdName"
@@ -198,11 +198,11 @@ initialize();
         >
             <template v-slot:top>
                 <v-toolbar class="bg-lightsecondary" flat>
-                    <v-toolbar-title>Products</v-toolbar-title>
+                    <v-toolbar-title>제품 목록</v-toolbar-title>
                     <v-spacer></v-spacer>
                     <v-dialog v-model="dialog" max-width="600px">
                         <template v-slot:activator="{ props }">
-                            <v-btn color="primary" variant="flat" dark v-bind="props">Add New Product</v-btn>
+                            <v-btn class="mr-2" color="primary" variant="tonal" v-bind="props">제품 생성</v-btn>
                         </template>
                         <v-card>
                             <v-card-title>
@@ -268,8 +268,8 @@ initialize();
                             </v-card-text>
                             <v-card-actions>
                                 <v-spacer></v-spacer>
-                                <v-btn color="primary" @click="save" :disabled="!formValid">Save Product</v-btn>
-                                <v-btn @click="close">Cancel</v-btn>
+                                <v-btn flat style="font-size: 15px; font-weight: 600;" color="primary" @click="save" :disabled="!formValid">저장</v-btn>
+                                <v-btn color="close" flat style="font-size: 15px; font-weight: 600;"  @click="close">닫기</v-btn>
                             </v-card-actions>
                         </v-card>
                     </v-dialog>
@@ -286,8 +286,20 @@ initialize();
                 </v-toolbar>
             </template>
             <template v-slot:item.actions="{ item }">
-                <v-icon small color="info" class="mr-2" @click="editItem(item)">mdi-pencil</v-icon>
-                <v-icon small color="error" @click="deleteItem(item)">mdi-delete</v-icon>
+                <EditIcon
+                    height="20"
+                    width="20"
+                    class="mr-2 text-primary cursor-pointer"
+                    size="small"
+                    @click="editItem(item)"
+                />
+                <TrashIcon
+                    height="20"
+                    width="20"
+                    class="text-error cursor-pointer"
+                    size="small"
+                    @click="deleteItem(item)"
+                />
             </template>
         </v-data-table>
     </UiParentCard>

--- a/src/views/apps/product/Product.vue
+++ b/src/views/apps/product/Product.vue
@@ -4,6 +4,11 @@ import api from '@/api/axiosinterceptor';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 const dialog = ref(false);
 // const dialogDelete = ref(false);
 const showConfirmDialog = ref(false);
@@ -132,14 +137,17 @@ async function save() {
             if (editedIndex.value > -1) {
                 await api.patch(`/admin/products/${editedItem.value.prodNo}`, editedItem.value);
                 Object.assign(items.value[editedIndex.value], editedItem.value);
+                triggerAlert('제품이 수정되었습니다.', 'success', 2000);
             } else {
                 const response = await api.post('/admin/products', editedItem.value);
                 items.value.push(response.data.result);
+                triggerAlert('제품이 등록되었습니다.', 'success', 2000);
             }
             fetchProducts();
             close();
         } catch (error) {
             console.error('저장 중 오류 발생:', error);
+            triggerAlert('제품 등록에  실패했습니다.', 'error', 2000);
         }
     }
 }
@@ -149,9 +157,11 @@ async function deleteItemConfirm() {
         const apiUrl = `/admin/products/${editedItem.value.prodNo}`;
         await api.delete(apiUrl);
         items.value.splice(editedIndex.value, 1);
+        triggerAlert('제품이 삭제되었습니다.', 'success', 2000);
         closeDelete();
     } catch (error) {
         console.error('삭제 중 오류 발생:', error);
+        triggerAlert('제품 삭제에 실패했습니다.', 'error', 2000);
     }
 }
 
@@ -183,6 +193,7 @@ initialize();
 </script>
 
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <UiParentCard title="관리 제품 목록">
         <v-row class="mb-5">
             <v-col cols="4" sm="4">

--- a/src/views/apps/product/Product.vue
+++ b/src/views/apps/product/Product.vue
@@ -2,9 +2,11 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import api from '@/api/axiosinterceptor';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 const dialog = ref(false);
-const dialogDelete = ref(false);
+// const dialogDelete = ref(false);
+const showConfirmDialog = ref(false);
 const formValid = ref(false);
 const departmentNames = ref([]);
 const searchProdName = ref('');
@@ -120,7 +122,8 @@ function editItem(item) {
 function deleteItem(item) {
     editedIndex.value = items.value.indexOf(item);
     editedItem.value = Object.assign({}, item);
-    dialogDelete.value = true;
+    // dialogDelete.value = true;
+    showConfirmDialog.value = true;
 }
 
 async function save() {
@@ -161,19 +164,20 @@ function close() {
 }
 
 function closeDelete() {
-    dialogDelete.value = false;
+    // dialogDelete.value = false;
+    showConfirmDialog.value = false;
     nextTick(() => {
         editedItem.value = Object.assign({}, defaultItem.value);
         editedIndex.value = -1;
     });
 }
 
-watch(dialog, (val) => {
-    if (!val) close();
-});
-watch(dialogDelete, (val) => {
-    if (!val) closeDelete();
-});
+// watch(dialog, (val) => {
+//     if (!val) close();
+// });
+// watch(dialogDelete, (val) => {
+//     if (!val) closeDelete();
+// });
 
 initialize();
 </script>
@@ -302,5 +306,7 @@ initialize();
                 />
             </template>
         </v-data-table>
+        <ConfirmDialogs :dialog="showConfirmDialog" @agree="deleteItemConfirm" @disagree="closeDelete"
+        />
     </UiParentCard>
 </template>

--- a/src/views/apps/sales/SalesChartView.vue
+++ b/src/views/apps/sales/SalesChartView.vue
@@ -10,12 +10,12 @@ const SalesPredictionChartView = defineAsyncComponent(() => import('./SalesPredi
 
 const breadcrumbs = ref([
     {
-        text: 'Chart',
+        text: '차트',
         disabled: false,
         href: 'sales'
     },
     {
-        text: 'Sales Chart',
+        text: '매출 차트',
         disabled: true,
         href: '#'
     }

--- a/src/views/apps/sales/SalesDetailView.vue
+++ b/src/views/apps/sales/SalesDetailView.vue
@@ -5,8 +5,7 @@
                 <div>총 매출 개수: {{ totalItems }}개</div>
             </v-col>
             <v-col cols="12" class="text-right">
-                <v-btn color="primary" @click="openModal" flat>
-                    <v-icon class="mr-2">mdi-account</v-icon>매출 추가
+                <v-btn color="primary" variant="tonal"  @click="openModal" flat> 매출 추가
                 </v-btn>
             </v-col>
         </v-row>

--- a/src/views/apps/sales/SalesDetailView.vue
+++ b/src/views/apps/sales/SalesDetailView.vue
@@ -1,4 +1,5 @@
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
     <div>
         <v-row>
             <v-col>
@@ -54,9 +55,11 @@
 <script>
 import SalesModal from './SalesModal.vue';
 import api from '@/api/axiosinterceptor';
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
 
 export default {
-    components: { SalesModal },
+    components: { SalesModal, AlertComponent },
     data() {
         return {
             sales: [], // 전체 매출 목록
@@ -82,6 +85,10 @@ export default {
             },
             search: '',
         };
+    },
+    setup() {
+        const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+        return { alertMessage, alertType, showAlert, triggerAlert };
     },
     mounted() {
         this.fetchSales();
@@ -165,13 +172,16 @@ export default {
             try {
                 if (sale.salesNo) {
                     await api.patch(`/sales/${sale.salesNo}`, sale);
+                    this.triggerAlert('매출이 수정되었습니다.', 'success', 2000);
                 } else {
                     await api.post('/sales', sale);
+                    this.triggerAlert('매출이 등록되었습니다.', 'success', 2000);
                 }
                 this.fetchSales();
                 this.closeModal();
             } catch (error) {
                 console.error('매출 저장에 실패했습니다:', error);
+                this.triggerAlert('매출 저장에 실패했습니다.', 'error', 2000);
             }
         },
     }

--- a/src/views/apps/sales/SalesModal.vue
+++ b/src/views/apps/sales/SalesModal.vue
@@ -22,9 +22,11 @@
         </v-form>
       </v-card-text>
       <v-card-actions>
-        <v-btn @click="saveSale">저장</v-btn>
-        <v-btn @click="handleClose">취소</v-btn>
-        <v-btn color="red" @click="deleteSale" v-if="sale.salesNo">삭제</v-btn> 
+        <v-btn color="primary" variant="outlined" @click="saveSale" flat style="font-size: 15px; font-weight: 600;">수정</v-btn>
+        <v-btn color="error" variant="outlined" @click="deleteSale" v-if="sale.salesNo" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
+        <v-spacer></v-spacer>
+        <v-btn color="close" @click="handleClose" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
+
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/views/apps/sales/SalesModal.vue
+++ b/src/views/apps/sales/SalesModal.vue
@@ -23,19 +23,23 @@
       </v-card-text>
       <v-card-actions>
         <v-btn color="primary" variant="outlined" @click="saveSale" flat style="font-size: 15px; font-weight: 600;">수정</v-btn>
-        <v-btn color="error" variant="outlined" @click="deleteSale" v-if="sale.salesNo" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
+        <v-btn color="error" variant="outlined" @click="openDeleteDialog" v-if="sale.salesNo" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
         <v-spacer></v-spacer>
         <v-btn color="close" @click="handleClose" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
 
       </v-card-actions>
     </v-card>
+    <ConfirmDialogs :dialog.sync="showConfirmDialog" @agree="deleteSale" @disagree="showConfirmDialog = false"
+    />
   </v-dialog>
 </template>
 
 <script>
 import api from '@/api/axiosinterceptor';
+import ConfirmDialogs from '@/components/shared/ConfirmDialogs.vue';
 
 export default {
+  components: { ConfirmDialogs },
   props: {
     value: Boolean,
     sale: {
@@ -46,6 +50,7 @@ export default {
   data() {
     return {
       valid: false,
+      showConfirmDialog : false
     };
   },
   computed: {
@@ -74,16 +79,19 @@ export default {
       this.isOpen = false;
       this.$emit('close');
     },
+    openDeleteDialog() {
+      this.showConfirmDialog = true;
+    },
     async deleteSale() {
-      if (confirm('정말로 이 매출을 삭제하시겠습니까?')) {
-        try {
-          await api.delete(`sales/${this.sale.salesNo}`);
-          this.$emit('deleted', this.sale.salesNo);
-          this.handleClose(); // 삭제 후 창 닫기
-        } catch (error) {
-          console.error('매출 삭제에 실패했습니다:', error);
-          alert('매출 삭제에 실패했습니다.');
-        }
+      try {
+        await api.delete(`sales/${this.sale.salesNo}`);
+        this.$emit('deleted', this.sale.salesNo);
+        this.handleClose();
+      } catch (error) {
+        console.error('매출 삭제에 실패했습니다:', error);
+        alert('매출 삭제에 실패했습니다.');
+      } finally {
+        this.showConfirmDialog = false;
       }
     },
     calculateTaxAndPrice() {

--- a/src/views/apps/sales/SalesModal.vue
+++ b/src/views/apps/sales/SalesModal.vue
@@ -22,7 +22,7 @@
         </v-form>
       </v-card-text>
       <v-card-actions>
-        <v-btn color="primary" variant="outlined" @click="saveSale" flat style="font-size: 15px; font-weight: 600;">수정</v-btn>
+        <v-btn color="primary" variant="outlined" @click="saveSale" flat style="font-size: 15px; font-weight: 600;">저장</v-btn>
         <v-btn color="error" variant="outlined" @click="openDeleteDialog" v-if="sale.salesNo" flat style="font-size: 15px; font-weight: 600;">삭제</v-btn>
         <v-spacer></v-spacer>
         <v-btn color="close" @click="handleClose" style="font-size: 15px; font-weight: 600;">닫기</v-btn>
@@ -89,7 +89,7 @@ export default {
         this.handleClose();
       } catch (error) {
         console.error('매출 삭제에 실패했습니다:', error);
-        alert('매출 삭제에 실패했습니다.');
+        // alert('매출 삭제에 실패했습니다.');
       } finally {
         this.showConfirmDialog = false;
       }

--- a/src/views/apps/sales/SalesPredictionChartView.vue
+++ b/src/views/apps/sales/SalesPredictionChartView.vue
@@ -13,18 +13,18 @@ interface SalesPredictionDto {
 
 const breadcrumbs = ref([
     {
-        text: 'Sales Chart',
+        text: '매출 Chart',
         disabled: false,
         href: 'sales predictions chart'
     },
     {
-        text: 'Sales Chart',
+        text: '매출 예측 Chart',
         disabled: true,
         href: '#'
     }
 ]);
 
-const page = ref({ title: 'Chart' });
+const page = ref({ title: '차트' });
 const monthlyChartData = ref<{ series: Array<{ name: string; data: number[] }> }>({
     series: []
 });

--- a/src/views/apps/sales/SalesStatusChartView.vue
+++ b/src/views/apps/sales/SalesStatusChartView.vue
@@ -9,17 +9,17 @@ const yearOptions = ref<number[]>([]);
 
 const breadcrumbs = ref([
     {
-        text: 'Sales Chart',
+        text: '매출 차트',
         disabled: false,
         href: 'sales status chart'
     },
     {
-        text: 'Sales Chart',
+        text: '매출 현황 차트',
         disabled: true,
         href: '#'
     }
 ]);
-const page = ref({ title: 'Chart' });
+const page = ref({ title: '차트' });
 
 for (let i = selectedYear.value - 9; i <= selectedYear.value; i++) {
     yearOptions.value.push(i);

--- a/src/views/apps/sbChart/ActChart.vue
+++ b/src/views/apps/sbChart/ActChart.vue
@@ -7,10 +7,10 @@ import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import ActChartClsCount from './ActChartClsCount.vue';
 
-const page = ref({ title: 'Chart' });
+const page = ref({ title: '차트' });
 const breadcrumbs = ref([
-    { text: 'Chart', disabled: false, href: '#' },
-    { text: 'Act Chart', disabled: true, href: '#' }
+    { text: '차트', disabled: false, href: '#' },
+    { text: '활동 차트', disabled: true, href: '#' }
 ]);
 </script>
 

--- a/src/views/apps/sbChart/ActChartCount.vue
+++ b/src/views/apps/sbChart/ActChartCount.vue
@@ -123,7 +123,7 @@ onMounted(() => {
           <v-select
               v-model="selectedYear"
               :items="yearOptions"
-              label="Select Year"
+              label="년도 선택"
               @update:model-value="onYearChange"
           />
       </v-col>

--- a/src/views/apps/targetSale/TargetSale.vue
+++ b/src/views/apps/targetSale/TargetSale.vue
@@ -3,12 +3,17 @@ import { ref, onMounted } from 'vue';
 import UiParentCard from '@/components/shared/UiParentCard.vue';
 import api from '@/api/axiosinterceptor';
 
+import { useAlert } from '@/utils/useAlert';
+import AlertComponent from '@/components/shared/AlertComponent.vue';
+
+const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
+
 const searchYear = ref('');
 const searchSalesperson = ref('');
 const targetSales = ref([]);
-const showAlert = ref(false);
-const alertMessage = ref('');
-const alertColor = ref('');
+// const showAlert = ref(false);
+// const alertMessage = ref('');
+// const alertColor = ref('');
 const canAddTargetSale = ref(false);
 const userNames = ref([]);
 const productNames = ref([]);
@@ -93,14 +98,16 @@ async function fetchTargetSales() {
     if (response.data.code === 200) {
       if (Array.isArray(response.data.result)) {
         targetSales.value = groupDataByProduct(response.data.result);
-        showAlert.value = false;
+        // showAlert.value = false;
         canAddTargetSale.value = true;
       }
     } else {
       canAddTargetSale.value = false;
-      alertMessage.value = '년도와 영업사원을 선택해주세요.';
-      alertColor.value = 'error';
-      showAlert.value = true;
+      
+      triggerAlert('년도와 영업사원을 선택해주세요.', 'warning', 2000);
+      // alertMessage.value = '년도와 영업사원을 선택해주세요.';
+      // alertColor.value = 'error';
+      // showAlert.value = true;
       targetSales.value = [];
       canAddTargetSale.value = false;
     }
@@ -134,8 +141,10 @@ async function saveTargetSale() {
     fetchTargetSales();
     closeDialog();
     console.log(response);
+    triggerAlert('목표매출이 등록되었습니다.', 'success', 2000);
   } catch (error) {
-    console.error('Error adding target sale:', error.message || error);
+    // console.error('Error adding target sale:', error.message || error);
+    triggerAlert('목표매출 등록에 실패했습니다.', 'error', 2000);
   }
 }
 
@@ -190,6 +199,7 @@ onMounted(() => {
 </script>
 
 <template>
+    <AlertComponent :show="showAlert" :message="alertMessage" :type="alertType" />
   <v-row>
     <v-col cols="12">
       <UiParentCard title="목표 매출 관리">
@@ -214,9 +224,9 @@ onMounted(() => {
           </v-col>
         </v-row>
 
-        <v-alert v-if="showAlert" class="mb-3" :color="alertColor" variant="tonal">
+        <!-- <v-alert v-if="showAlert" class="mb-3" :color="alertColor" variant="tonal">
           {{ alertMessage }}
-        </v-alert>
+        </v-alert> -->
 
         <v-data-table
           class="border rounded-md" 
@@ -251,7 +261,7 @@ onMounted(() => {
           </template>
           <template v-slot:top>
             <v-toolbar class="bg-lightsecondary" flat>
-              <v-toolbar-title>Target Sale</v-toolbar-title>
+              <v-toolbar-title>목표 매출</v-toolbar-title>
               <v-spacer></v-spacer>
               <v-btn 
                 class="mr-3"

--- a/src/views/apps/targetSale/TargetSale.vue
+++ b/src/views/apps/targetSale/TargetSale.vue
@@ -192,11 +192,11 @@ onMounted(() => {
 <template>
   <v-row>
     <v-col cols="12">
-      <UiParentCard title="Target sales management">
+      <UiParentCard title="목표 매출 관리">
         <v-row class="mb-5">
           <v-col cols="4" sm="4">
             <v-select
-              label="Select Year"
+              label="년도 선택"
               v-model="searchYear"
               :items="yearRange"
               hide-details
@@ -206,7 +206,7 @@ onMounted(() => {
             <v-select
               v-model="searchSalesperson"
               :items="userNames"
-              label="Select Salesperson"
+              label="영업사원 선택"
             ></v-select>
           </v-col>
           <v-col cols="4">
@@ -239,9 +239,13 @@ onMounted(() => {
               <td>{{ item.month11 }}</td>
               <td>{{ item.month12 }}</td>
               <td>
-                <v-icon color="info" size="small" class="me-2" @click.stop="editTargetSale(item)">
-                  mdi-pencil
-                </v-icon>
+                <EditIcon
+                    height="20"
+                    width="20"
+                    class="mr-2 text-primary cursor-pointer"
+                    size="small"
+                    @click.stop="editTargetSale(item)"
+                />
               </td>
             </tr>
           </template>
@@ -250,12 +254,13 @@ onMounted(() => {
               <v-toolbar-title>Target Sale</v-toolbar-title>
               <v-spacer></v-spacer>
               <v-btn 
+                class="mr-3"
                 v-if="canAddTargetSale" 
                 color="primary" 
-                variant="flat" 
+                variant="tonal" 
                 dark 
                 @click.stop="openDialog">
-                Add New TargetSale
+                목표 매출 생성
               </v-btn>
             </v-toolbar>
           </template>
@@ -266,7 +271,7 @@ onMounted(() => {
 
   <v-dialog v-model="dialog" max-width="600px">
     <v-card>
-      <v-card-title>{{ isEditMode ? 'Update TargetSales' : 'Add TargetSales' }}</v-card-title>
+      <v-card-title>{{ isEditMode ? '목표매출 수정' : '목표매출 등록' }}</v-card-title>
       <v-card-text>
         <v-container>
           <v-form v-model="formValid">
@@ -290,8 +295,8 @@ onMounted(() => {
         </v-container>
       </v-card-text>
       <v-card-actions>
-        <v-btn color="primary" @click="saveTargetSale()" :disabled="!formValid">Save</v-btn>
-        <v-btn @click="closeDialog">Cancel</v-btn>
+        <v-btn color="primary" flat style="font-size: 15px; font-weight: 600;" @click="saveTargetSale()" :disabled="!formValid">저장</v-btn>
+        <v-btn color="close" flat style="font-size: 15px; font-weight: 600;" @click="closeDialog">닫기</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>


### PR DESCRIPTION
## 💬 작업 내용 설명
- 버튼
  - 버튼 색상 설정" 저장 - `primary`, 수정 - `info` 또는 `primary`,경고-`warning`, 삭제 - `error`, 취소/닫기 - `close`
  - 텍스트 한글 통일: 버튼 텍스트는 한글로 통일
  - 위치: 폼 페이지 버튼은 좌측 하단에 정렬
  - 불필요한 아이콘 삭제
  - 버튼 텍스트 통일:
    - `생성`으로 통일
    - 검색 버튼은 `검색`으로 통일
    - 추가 모달은 도메인명 + 등록 형식으로 (예: "견적 등록")
- 삭제 다이얼로그: 커스텀 `ConfirmDialogs`로 통일
- 확인 다이얼로그 생성
- 성공 및 경고 alert 창 통일: 캘린더에서 사용하는 alert 형식으로 변경
- 다이얼로그: alert 창에서 다이얼로그 감싸는 코드 제거
- 페이지 제목 표시: 현재 위치 및 경로 표시(일부 페이지 미작업)
- 언어 통일: 모든 텍스트는 한글

<br>

<br>

## #️⃣연관된  issue
close #136

<br>

## ✅ 체크리스트
- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 파일 혹은 폴더명 수정
- [X] 파일 혹은 폴더 삭제
- [X] 코드 중간 통합

<br>

## 📑To Reviewers

도메인별 변경 사항 캡처해놨으니까 링크 참고해주세요
https://thoughtful-ellipse-826.notion.site/12c939a0159380e8a0b0dcf51ca962f6?pvs=4
