### PR TITLE
[Feat/#140]  고객 삭제, 수정 로직 변경

### DIFF
--- a/src/components/customer/UpdateForm.vue
+++ b/src/components/customer/UpdateForm.vue
@@ -88,7 +88,8 @@ const updateCustomerAPI = async(id)=>{
             //     router.push({ name: "Customer" });
             // }, 2000); 
         }else{
-            triggerAlert(response.data.result,'warning');
+            triggerAlert(response.data.message,'warning');
+            showEditConfirmDialog.value = false; 
         }
 
     }catch(err){
@@ -108,7 +109,8 @@ const deleteCustoemrAPI = async(id)=>{
                 router.push({ name: "Customer" });
             }, 2000); 
         }else{
-            triggerAlert(response.data.result,'warning');
+            triggerAlert(response.data.message,'warning');
+            showDeleteConfirmDialog.value = false; 
         }
 
     }catch(err){

--- a/src/components/customer/UpdateForm.vue
+++ b/src/components/customer/UpdateForm.vue
@@ -1,11 +1,11 @@
-<script setup lang="ts">
+<script setup>
 import { computed, onMounted, ref ,nextTick } from 'vue';
 import api from '@/api/axiosinterceptor';
 import { useRouter ,useRoute} from 'vue-router';
-import { mask } from 'maska'; 
 import { useAlert } from '@/utils/useAlert';
 import AlertComponent from '@/components/shared/AlertComponent.vue';
 import EditConfirmDialog from '../../components/shared/EditConfirmDialog.vue';
+import ConfirmDialogs from '../shared/ConfirmDialogs.vue';
 
 const { alertMessage, alertType, showAlert, triggerAlert } = useAlert();
 
@@ -20,8 +20,11 @@ const phone = ref(null);
 const tel = ref(null);
 const grade = ref(null);
 const isKeyMan = ref(false);
+const userEmail = ref();
+const loggedInUserEmail = ref(localStorage.getItem("loginUserEmail"));
 
 const showEditConfirmDialog = ref(false);
+const showDeleteConfirmDialog = ref(false);
 
 const router = useRouter();
 const route = useRoute();
@@ -30,14 +33,13 @@ onMounted(()=>{
     getCustomerInfoAPI(route.params.id);
 })
 const updateCustomer = ()=>{
-
     showEditConfirmDialog.value = true; 
-//     if(confirm("고객정보를 수정하시겠습니까?")){
-//         updateCustomerAPI(route.params.id);
-//     }
+}
+const deleteCustomer =()=>{
+    showDeleteConfirmDialog.value = true;
 }
 
-const getCustomerInfoAPI = async(id: string | string[])=>{
+const getCustomerInfoAPI = async(id)=>{
     try{
         const res = await api.get(`/customers/${id}`);
         if(res.data.code==200){
@@ -51,6 +53,8 @@ const getCustomerInfoAPI = async(id: string | string[])=>{
             company.value = info.company;
             grade.value = info.grade;
             isKeyMan.value = info.keyMan;
+            userEmail.value = info.userEmail;
+
 
             await nextTick();
 
@@ -63,7 +67,7 @@ const getCustomerInfoAPI = async(id: string | string[])=>{
     }
 }
 
-const updateCustomerAPI = async(id:string|string[])=>{
+const updateCustomerAPI = async(id)=>{
     try{
         const response = await api.patch(`/customers/${id}`,{
             name:customerName.value,
@@ -79,11 +83,12 @@ const updateCustomerAPI = async(id:string|string[])=>{
         console.log(response.data);
         if(response.data.code==200){
             triggerAlert('수정이 완료되었습니다.', 'success');
-            // getCustomerInfoAPI(route.params.id);
             showEditConfirmDialog.value = false; 
-            setTimeout(() => {
-                router.push({ name: "Customer" });
-            }, 2000); 
+            // setTimeout(() => {
+            //     router.push({ name: "Customer" });
+            // }, 2000); 
+        }else{
+            triggerAlert(response.data.result,'warning');
         }
 
     }catch(err){
@@ -92,28 +97,50 @@ const updateCustomerAPI = async(id:string|string[])=>{
 
 }
 
+const deleteCustoemrAPI = async(id)=>{
+    try{
+        const response = await api.delete(`/customers/${id}`);
+        console.log(response);
+        if(response.data.code == 200){
+            triggerAlert(response.data.message,'success');
+            showDeleteConfirmDialog.result = false;
+            setTimeout(() => {
+                router.push({ name: "Customer" });
+            }, 2000); 
+        }else{
+            triggerAlert(response.data.result,'warning');
+        }
+
+    }catch(err){
+        console.log(`[ERROR 메세지] : ${err}`);
+    }
+
+}
+
+
 const confirmName = ref([
-    (s:string)=> !! s|| '고객명을 입력해주세요'
+    (s)=> !! s|| '고객명을 입력해주세요'
 ]);
 
 // 휴대폰 번호
 const confirmPhone = ref([
-    (s:string) => !!s|| '휴대폰 번호를 입력해주세요'
+    (s) => !!s|| '휴대폰 번호를 입력해주세요'
 ])
 // 등급
 const confirmGrade = ref([
-(v: string) => !!v || '등급을 선택해주세요'
+(v) => !!v || '등급을 선택해주세요'
 ]);
 
 
 // 이메일
-const confirmEmail = ref([(v: string) => !!v || '이메일을 입력해주세요', (v: string) => /.+@.+\..+/.test(v) || '이메일 형식으로 입력해주세요']);
+const confirmEmail = ref([(v) => !!v || '이메일을 입력해주세요', (v) => /.+@.+\..+/.test(v) || '이메일 형식으로 입력해주세요']);
 
 
 const formIsValid = computed(()=>{
     return customerName.value && email.value && grade.value && phone.value;
 })
 
+const isAssignedUser = computed(()=> userEmail.value === loggedInUserEmail.value);
 
 </script>
 <template>
@@ -185,8 +212,16 @@ const formIsValid = computed(()=>{
         @close="showEditConfirmDialog = false"
     />
 
+    <ConfirmDialogs
+        :dialog="showDeleteConfirmDialog"
+        message="고객정보를 삭제하시겠습니까?"
+        @agree="deleteCustoemrAPI(route.params.id)"
+        @disagree="showDeleteConfirmDialog = false"
+    />
+
     <div class="d-flex gap-2 mt-5 justify-content flex-column flex-wrap flex-xl-nowrap flex-sm-row fill-height"> 
-        <v-btn color="primary" variant="flat" @click="updateCustomer" :disabled="!formIsValid">수정</v-btn>
+        <v-btn v-if="isAssignedUser"  color="primary" variant="flat" @click="updateCustomer" :disabled="!formIsValid">수정</v-btn>
+        <v-btn v-if="isAssignedUser" color="error" class="mr-2"  @click="deleteCustomer">삭제</v-btn>
         <v-btn color="info" variant="outlined" to="/sales/contact">목록으로 돌아가기</v-btn>
     </div>   
 </template>


### PR DESCRIPTION
## 💬 작업 내용 설명
- 고객 삭제
   - 담당자만 삭제 버튼이 보이게 변경
- 고객 수정
   - 담당자만 수정 버튼이 보이게 변경


<br>

<details>
  <summary> 타인이 등록한 고객 조회 </summary>
<img width="1340" alt="스크린샷 2024-10-28 오후 10 10 38" src="https://github.com/user-attachments/assets/e044aa83-8661-4eee-9262-06789537345d">


</details>
<details>
  <summary> 내가 등록한 고객 조회</summary>
<img width="1349" alt="스크린샷 2024-10-28 오후 10 11 50" src="https://github.com/user-attachments/assets/1eb69e6d-52be-4af9-ae8e-85ce3b20610f">

</details>

<details>
  <summary> 내가 등록한 고객 수정</summary>

<img width="1072" alt="스크린샷 2024-10-28 오후 10 06 42" src="https://github.com/user-attachments/assets/0bb98855-e776-41f9-931b-332b91b78af1">
<img width="1391" alt="스크린샷 2024-10-28 오후 10 18 51" src="https://github.com/user-attachments/assets/34f93821-d5bd-4471-9e15-588b2f18cd2d">

</details>


<details>
  <summary> 내가 등록한 고객 삭제</summary>

<img width="1182" alt="스크린샷 2024-10-28 오후 10 07 50" src="https://github.com/user-attachments/assets/5038d66c-c6ed-412a-8355-b47f47b7f5fa">

</details>


<details>
  <summary> 수정/삭제 실패 </summary>
 서버에서 예외처리한 에러 메세지 출력

<img width="1402" alt="스크린샷 2024-10-28 오후 10 17 00" src="https://github.com/user-attachments/assets/5c5e9b78-753b-4f4b-9f4f-4eb1f382f28f">

<img width="1453" alt="스크린샷 2024-10-28 오후 10 17 56" src="https://github.com/user-attachments/assets/19dd0769-3f40-4b41-a087-1fe5f4fbf0b3">


</details>




## #️⃣연관된  issue
#140

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링


<br>

## 📑To Reviewers (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분
