### PR TITLE
[Feat/#127] 영업 예측 페이지 구현

### DIFF
--- a/src/components/auth/LoginForm.vue
+++ b/src/components/auth/LoginForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref,computed } from 'vue';
+import { ref, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { Form } from 'vee-validate';
 import baseApi from '@/api/baseapi';
@@ -12,94 +12,101 @@ const email = ref('');
 const employeeId = ref('');
 const router = useRouter();
 const authStore = useAuthStore();
-const dialog=ref(false);
+const dialog = ref(false);
 const isLoading = ref(false);
 
 const passwordRules = ref([
     (v: string) => !!v || '비밀번호를 입력해주세요',
     (v: string) => (v && v.length >= 4) || '비밀번호는 4자리 이상으로 입력해주세요'
 ]);
-const emailRules = ref([(v: string) => !!v || '이메일을 입력해주세요', (v: string) => /.+@.+\..+/.test(v) || '이메일 형식으로 입력해주세요']);
+const emailRules = ref([
+    (v: string) => !!v || '이메일을 입력해주세요',
+    (v: string) => /.+@.+\..+/.test(v) || '이메일 형식으로 입력해주세요'
+]);
 
 const employeeIdRules = ref([(v: string) => !!v || '사원번호를 입력해주세요']);
 
-const formIsValid = computed(()=>{// 계산된 속성 사용
-    if(isEmployeeIdLogin.value){
+const formIsValid = computed(() => {
+    // 계산된 속성 사용
+    if (isEmployeeIdLogin.value) {
         return employeeId.value && password.value;
-    }else{
+    } else {
         return email.value && password.value;
     }
-})
+});
 
-
-const login =()=>{
-    if(formIsValid.value){
+const login = () => {
+    if (formIsValid.value) {
         loginApi();
     }
-}
+};
 
-const loginApi=async()=>{
-    try{
+const loginApi = async () => {
+    try {
         isLoading.value = true;
-        const res = await baseApi.post('/users/login',{
-            loginType: isEmployeeIdLogin.value ? 'employeeId':'email', // 로그인 방식 구분
-            email: email.value ? email.value : null,
-            employeeId : employeeId.value? employeeId.value : null,
-            password: password.value 
-        },
-        {
-            withCredentials: true
-        }
-    )
-        if(res.data.code==200){
-            alert("로그인을 완료했습니다.");
+        const res = await baseApi.post(
+            '/users/login',
+            {
+                loginType: isEmployeeIdLogin.value ? 'employeeId' : 'email', // 로그인 방식 구분
+                email: email.value ? email.value : null,
+                employeeId: employeeId.value ? employeeId.value : null,
+                password: password.value
+            },
+            {
+                withCredentials: true
+            }
+        );
+        if (res.data.code == 200) {
+            alert('로그인을 완료했습니다.');
             const result = res.data.result;
             console.log(result);
             authStore.setIsLogedIn();
             saveLocalStorage(result);
-            router.push("/");  
+            router.push('/');
         }
-    }catch(err) {
+    } catch (err) {
         console.log(err);
-    }finally{
+    } finally {
         isLoading.value = false;
     }
-
-}
-const saveLocalStorage=(result:any)=>{
-        localStorage.setItem('loginUserName', result.name);
-        localStorage.setItem('loginUserEmail', result.email);
-        localStorage.setItem('accessToken',result.accessToken);
-        localStorage.setItem('loginUserRole',result.role);
-}
+};
+const saveLocalStorage = (result: any) => {
+    localStorage.setItem('loginUserNo', result.userNo);
+    localStorage.setItem('loginDeptNo', result.deptNo);
+    localStorage.setItem('loginUserName', result.name);
+    localStorage.setItem('loginUserEmail', result.email);
+    localStorage.setItem('accessToken', result.accessToken);
+    localStorage.setItem('loginUserRole', result.role);
+};
 
 // const findPassword = ()=>{
 //      dialog.value = true  // 창 열기
 // }
 
-const closeModal = ()=>{
-     dialog.value = false;  // 닫기
-}
-const saveHistory = ()=>{
-     dialog.value = false;
-}
+const closeModal = () => {
+    dialog.value = false; // 닫기
+};
+const saveHistory = () => {
+    dialog.value = false;
+};
 </script>
 
 <template>
     <div class="d-flex align-center text-center mb-6">
         <div class="text-h6 w-100 px-5 font-weight-regular position-relative">
             <span class="bg-surface px-5 py-3 position-relative">영업관리 로그인</span>
-        </div>  
+        </div>
     </div>
     <Form class="mt-5">
-          <!-- 로그인 방식 선택 (체크박스 또는 스위치) -->
-          <v-progress-circular v-if="isLoading" indeterminate color="primary" size="50"
-          style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);"></v-progress-circular>
-        <v-switch
-            v-model="isEmployeeIdLogin"
+        <!-- 로그인 방식 선택 (체크박스 또는 스위치) -->
+        <v-progress-circular
+            v-if="isLoading"
+            indeterminate
             color="primary"
-            label="사번으로 로그인" inset>
-        </v-switch>
+            size="50"
+            style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)"
+        ></v-progress-circular>
+        <v-switch v-model="isEmployeeIdLogin" color="primary" label="사번으로 로그인" inset> </v-switch>
         <v-label class="text-subtitle-1 font-weight-medium pb-2 text-lightText" v-if="!isEmployeeIdLogin">이메일</v-label>
         <VTextField
             v-if="!isEmployeeIdLogin"
@@ -111,7 +118,7 @@ const saveHistory = ()=>{
             hide-details="auto"
         ></VTextField>
 
-        <v-label class="text-subtitle-1 font-weight-medium pb-2 text-lightText"  v-if="isEmployeeIdLogin">사원번호</v-label>
+        <v-label class="text-subtitle-1 font-weight-medium pb-2 text-lightText" v-if="isEmployeeIdLogin">사원번호</v-label>
         <VTextField
             v-if="isEmployeeIdLogin"
             v-model="employeeId"
@@ -133,13 +140,13 @@ const saveHistory = ()=>{
         ></VTextField>
         <!-- <PasswordResetModal :dialog="dialog" @update:dialog="dialog=$event" @close="closeModal" @save="saveHistory"/> -->
         <div class="d-flex flex-wrap align-center my-3 ml-n2">
-           
             <div class="ml-sm-auto">
-                <RouterLink to="/auth/find-password" class="text-primary text-decoration-none text-body-1 opacity-1 font-weight-medium">비밀번호 찾기</RouterLink
+                <RouterLink to="/auth/find-password" class="text-primary text-decoration-none text-body-1 opacity-1 font-weight-medium"
+                    >비밀번호 찾기</RouterLink
                 >
             </div>
         </div>
-        <v-btn size="large" :disabled="!formIsValid"  color="primary" block flat @click="login" >로그인</v-btn>
+        <v-btn size="large" :disabled="!formIsValid" color="primary" block flat @click="login">로그인</v-btn>
         <!-- <div v-if="errors.apiError" class="mt-2">
             <v-alert color="error">{{ errors.apiError }}</v-alert>
         </div> -->

--- a/src/components/lead/DetailForm.vue
+++ b/src/components/lead/DetailForm.vue
@@ -490,7 +490,7 @@ onMounted(() => {
                                     append-inner-icon="mdi-magnify"
                                     @click:append-inner="customerDialog = true"
                                 ></v-text-field>
-                                <v-label class="mb-2 font-weight-medium">예상매출</v-label>
+                                <v-label class="mb-2 font-weight-medium">예상매출(원)</v-label>
                                 <v-text-field
                                     v-model="expSalesDisplay"
                                     variant="outlined"
@@ -498,7 +498,7 @@ onMounted(() => {
                                     maxlength="14"
                                     @input="updateExpSales"
                                 ></v-text-field>
-                                <v-label class="mb-2 font-weight-medium">예상이익금액</v-label>
+                                <v-label class="mb-2 font-weight-medium">예상이익금액(원)</v-label>
                                 <v-text-field
                                     v-model="expProfitDisplay"
                                     variant="outlined"
@@ -517,7 +517,7 @@ onMounted(() => {
                                     :rules="[requiredRule]"
                                     variant="outlined"
                                 ></v-select>
-                                <v-label class="mb-2 font-weight-medium">예상이익률</v-label>
+                                <v-label class="mb-2 font-weight-medium">예상이익률(%)</v-label>
                                 <v-text-field
                                     v-model="expMarginDisplay"
                                     variant="outlined"
@@ -559,10 +559,11 @@ onMounted(() => {
                                     readonly
                                     variant="outlined"
                                     color="primary"
+                                    :disabled="true"
                                 ></v-text-field>
                             </v-col>
                             <v-col cols="12" md="3">
-                                <v-label class="mb-2 font-weight-medium">성공확률</v-label>
+                                <v-label class="mb-2 font-weight-medium">성공확률(%)</v-label>
                                 <v-text-field
                                     v-model="leadResponseDto.successPer"
                                     variant="outlined"

--- a/src/components/lead/Month.vue
+++ b/src/components/lead/Month.vue
@@ -1,0 +1,216 @@
+<script setup>
+import { computed, reactive, ref, watch } from 'vue';
+import { getPrimary, getSecondary } from '@/utils/UpdateColors';
+import { TicketIcon, ReceiptIcon, MoneybagIcon, ChartLineIcon } from 'vue-tabler-icons';
+
+const props = defineProps({
+    monthData: {
+        type: [Object, Function],
+        default: () => ({})
+    }
+});
+
+const formatNumber = (value) => {
+    return new Intl.NumberFormat().format(value);
+};
+
+const chartData = reactive({
+    series: [
+        {
+            name: '예상계약금액',
+            type: 'column',
+            data: []
+        },
+        {
+            name: '예상이익금액',
+            type: 'column',
+            data: []
+        },
+        {
+            name: '건',
+            type: 'line',
+            data: []
+        }
+    ]
+});
+
+const leadCount = ref(0);
+const sales = ref(0);
+const profit = ref(0);
+const margin = ref(0);
+
+watch(
+    () => props.monthData,
+    (newMonthData) => {
+        leadCount.value = newMonthData.totalLeadCount;
+        sales.value = newMonthData.totalSales;
+        profit.value = newMonthData.totalProfit;
+        margin.value = parseFloat(((profit.value / sales.value) * 100).toFixed(2));
+        chartData.series[0].data = newMonthData.monthExpSales;
+        chartData.series[1].data = newMonthData.monthExpProfit;
+        chartData.series[2].data = newMonthData.monthLeadCount;
+    }
+);
+
+const chartOptions = computed(() => ({
+    chart: {
+        type: 'line',
+        height: 350,
+        stacked: false,
+        toolbar: {
+            show: true,
+            tools: {
+                download: true,
+                selection: false,
+                zoom: false,
+                zoomin: false,
+                zoomout: false,
+                pan: false,
+                reset: false
+            }
+        }
+    },
+    colors: [getPrimary.value, getSecondary.value, 'gray'],
+    dataLabels: {
+        enabled: true,
+        enabledOnSeries: [2]
+    },
+    stroke: {
+        width: [2, 2, 4],
+        curve: 'smooth'
+    },
+    xaxis: {
+        categories: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+    },
+    yaxis: [
+        {
+            seriesName: '예상계약금액',
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: getPrimary.value
+            },
+            labels: {
+                formatter: (val) => `${formatNumber(val)}`,
+                style: {
+                    colors: getPrimary.value
+                }
+            },
+            tooltip: {
+                enabled: true
+            }
+        },
+        {
+            seriesName: '예상이익금액',
+            opposite: true,
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: getSecondary.value
+            },
+            labels: {
+                formatter: (val) => `${formatNumber(val)}`,
+                style: {
+                    colors: getSecondary.value
+                }
+            }
+        },
+        {
+            show: false,
+            seriesName: '건',
+            opposite: true,
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: '#FEB019'
+            },
+            labels: {
+                formatter: (val) => `${Math.floor(val)}`,
+                style: {
+                    colors: '#FEB019'
+                }
+            }
+        }
+    ],
+    tooltip: {
+        fixed: {
+            enabled: true,
+            position: 'topLeft',
+            offsetY: 30,
+            offsetX: 60
+        }
+    },
+    legend: {
+        position: 'bottom'
+    },
+    responsive: [
+        {
+            breakpoint: 600,
+            options: {
+                yaxis: {
+                    show: false
+                }
+            }
+        }
+    ]
+}));
+</script>
+
+<template>
+    <v-row>
+        <v-col cols="12" lg="3">
+            <v-card class="bg-primary" elevation="10">
+                <v-card-text class="pa-6">
+                    <component :is="TicketIcon" stroke-width="1.5" size="25" />
+                    <h5 class="text-h5 mt-2 text-white">전체</h5>
+                    <span class="text-white">{{ leadCount }} 건</span>
+                </v-card-text>
+            </v-card>
+        </v-col>
+        <v-col cols="12" lg="3">
+            <v-card class="second" elevation="10">
+                <v-card-text class="pa-6">
+                    <component class="text-white" :is="ReceiptIcon" stroke-width="1.5" size="25" />
+                    <h5 class="text-h5 mt-2 text-white">예상매출금액</h5>
+                    <span class="text-white">{{ formatNumber(sales) }} 천원</span>
+                </v-card-text>
+            </v-card>
+        </v-col>
+        <v-col cols="12" lg="3">
+            <v-card class="bg-secondary" elevation="10">
+                <v-card-text class="pa-6">
+                    <component :is="MoneybagIcon" stroke-width="1.5" size="25" />
+                    <h5 class="text-h5 mt-2 text-white">예상이익금액</h5>
+                    <span class="text-white">{{ formatNumber(profit) }} 천원</span>
+                </v-card-text>
+            </v-card>
+        </v-col>
+        <v-col cols="12" lg="3">
+            <v-card class="bg-success" elevation="10">
+                <v-card-text class="pa-6">
+                    <component :is="ChartLineIcon" stroke-width="1.5" size="25" />
+                    <h5 class="text-white text-h5 mt-2">예상이익률</h5>
+                    <span class="text-white">{{ margin }} %</span>
+                </v-card-text>
+            </v-card>
+        </v-col>
+    </v-row>
+    <VCardSubtitle class="subtitle my-3">단위 : (건/천원)</VCardSubtitle>
+    <apexchart type="line" height="400" :options="chartOptions" :series="chartData.series"> </apexchart>
+</template>
+
+<style lang="scss" scoped>
+.subtitle {
+    text-align: right;
+}
+
+.second {
+    background-color: #008dc9;
+}
+</style>

--- a/src/components/lead/Path.vue
+++ b/src/components/lead/Path.vue
@@ -1,0 +1,180 @@
+<script setup>
+import { computed, watch, reactive } from 'vue';
+import { getPrimary, getSecondary } from '@/utils/UpdateColors';
+
+const props = defineProps({
+    pathData: {
+        type: [Object, Function],
+        default: () => ({})
+    }
+});
+
+const formatNumber = (value) => {
+    return new Intl.NumberFormat().format(value);
+};
+
+const chartData = reactive({
+    labels: [],
+    series: [
+        {
+            name: '예상계약금액',
+            type: 'column',
+            data: []
+        },
+        {
+            name: '예상이익금액',
+            type: 'column',
+            data: []
+        },
+        {
+            name: '건',
+            type: 'line',
+            data: []
+        }
+    ]
+});
+
+watch(
+    () => props.pathData,
+    (newData) => {
+        chartData.labels = newData.map((item) => getPathName(item.awarePath));
+        chartData.series[0].data = newData.map((item) => item.totalExpSales);
+        chartData.series[1].data = newData.map((item) => item.totalExpProfit);
+        chartData.series[2].data = newData.map((item) => item.leadCount);
+    }
+);
+
+const getPathName = (path) => {
+    const pathNames = {
+        EXISTING: '기존고객',
+        ETC: '기타',
+        DEMO: '데모체험',
+        NEWSPAPER: '신문',
+        SEARCH: '인터넷검색',
+        EDUCATION: '정규교육',
+        INTRODUCE: '지인소개',
+        PARTNER: '파트너사'
+    };
+    return pathNames[path] || '';
+};
+
+const chartOptions = computed(() => ({
+    chart: {
+        type: 'line',
+        height: 350,
+        stacked: false,
+        toolbar: {
+            show: true,
+            tools: {
+                download: true,
+                selection: false,
+                zoom: false,
+                zoomin: false,
+                zoomout: false,
+                pan: false,
+                reset: false
+            }
+        }
+    },
+    colors: [getPrimary.value, getSecondary.value, 'gray'],
+    dataLabels: {
+        enabled: true,
+        enabledOnSeries: [2]
+    },
+    stroke: {
+        width: [2, 2, 4],
+        curve: 'smooth'
+    },
+    xaxis: {
+        categories: chartData.labels
+    },
+    yaxis: [
+        {
+            seriesName: '예상계약금액',
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: getPrimary.value
+            },
+            labels: {
+                formatter: (val) => `${formatNumber(val)}`,
+                style: {
+                    colors: getPrimary.value
+                }
+            },
+            tooltip: {
+                enabled: true
+            }
+        },
+        {
+            seriesName: '예상이익금액',
+            opposite: true,
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: getSecondary.value
+            },
+            labels: {
+                formatter: (val) => `${formatNumber(val)}`,
+                style: {
+                    colors: getSecondary.value
+                }
+            }
+        },
+        {
+            show: false,
+            seriesName: '건',
+            opposite: true,
+            axisTicks: {
+                show: true
+            },
+            axisBorder: {
+                show: true,
+                color: '#FEB019'
+            },
+            labels: {
+                formatter: (val) => `${Math.floor(val)}`,
+                style: {
+                    colors: '#FEB019'
+                }
+            }
+        }
+    ],
+    tooltip: {
+        fixed: {
+            enabled: true,
+            position: 'topLeft',
+            offsetY: 30,
+            offsetX: 60
+        }
+    },
+    legend: {
+        position: 'bottom'
+    },
+    responsive: [
+        {
+            breakpoint: 600,
+            options: {
+                yaxis: {
+                    show: false
+                }
+            }
+        }
+    ]
+}));
+</script>
+
+<template>
+    <VCardSubtitle class="subtitle">단위 : (건/천원)</VCardSubtitle>
+    <apexchart type="line" height="300" :options="chartOptions" :series="chartData.series"></apexchart>
+</template>
+
+<style lang="scss" scoped>
+.subtitle {
+    text-align: right;
+}
+</style>

--- a/src/components/lead/Process.vue
+++ b/src/components/lead/Process.vue
@@ -1,0 +1,47 @@
+<template>
+    <VCardSubtitle class="subtitle">단위 : (건/천원)</VCardSubtitle>
+    <v-row>
+        <v-col cols="12">
+            <v-row v-for="(process, label) in processData" :key="label" align="center" class="py-2">
+                <v-col cols="3" class="d-flex align-center">
+                    <v-avatar color="white" size="40" class="mr-2">
+                        <v-icon :color="process.color">mdi-cube-outline</v-icon>
+                    </v-avatar>
+                    <span :style="{ color: process.color, fontWeight: 'bold' }">{{ process.label }}</span>
+                </v-col>
+                <v-col cols="3">
+                    <span>{{ process.count }} 건</span>
+                </v-col>
+                <v-col cols="3" class="text-center">
+                    <span>{{ process.amount.toLocaleString() }}</span>
+                </v-col>
+                <v-col cols="2" class="text-right">
+                    <v-avatar color="grey lighten-3" size="16">
+                        <v-icon :color="process.color">mdi-circle</v-icon>
+                    </v-avatar>
+                </v-col>
+            </v-row>
+        </v-col>
+    </v-row>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const processData = ref([
+    { label: '인지', color: '#ff9800', count: 3, amount: 100 },
+    { label: '제안', color: '#00bcd4', count: 1, amount: 0 },
+    { label: '협상', color: '#607d8b', count: 0, amount: 0 },
+    { label: '계약', color: '#ff5722', count: 2, amount: 11500 }
+]);
+</script>
+
+<style lang="scss" scoped>
+.subtitle {
+    text-align: right;
+}
+
+.text-h6 {
+    font-weight: bold;
+}
+</style>

--- a/src/components/lead/Status.vue
+++ b/src/components/lead/Status.vue
@@ -1,0 +1,102 @@
+<script setup>
+import { ref, watch, computed } from 'vue';
+
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const props = defineProps({
+    statusData: {
+        type: [Object, Function, Array],
+        default: () => []
+    }
+});
+
+const formattedStatusData = computed(() => {
+    if (!Array.isArray(props.statusData)) return [];
+
+    const dataCopy = [...props.statusData];
+    dataCopy[0].status = 'ALL';
+    const allCount = dataCopy.find((item) => item.status === 'ALL')?.count || 1;
+
+    return dataCopy.map((item) => ({
+        ...item,
+        percentage: item.status === 'ALL' ? 100 : parseFloat(((item.count / allCount) * 100).toFixed(2))
+    }));
+});
+
+const formatNumber = (value) => {
+    return new Intl.NumberFormat().format(value);
+};
+
+const getStatusName = (status) => {
+    const statusNames = {
+        ALL: '등록',
+        PROGRESS: '진행중',
+        SUCCESS: '성공',
+        HOLD: '보류',
+        FAIL: '실패'
+    };
+    return statusNames[status] || '';
+};
+
+const getColor = (status) => {
+    const statusColors = {
+        ALL: 'primary',
+        PROGRESS: 'secondary',
+        SUCCESS: 'success',
+        HOLD: 'warning',
+        FAIL: 'error'
+    };
+    return statusColors[status] || 'grey';
+};
+</script>
+
+<template>
+    <VCardSubtitle class="subtitle">단위 : (건/천원)</VCardSubtitle>
+    <v-row>
+        <v-col cols="12">
+            <v-row v-for="(data, index) in formattedStatusData" :key="index" align="center" class="py-2">
+                <v-col cols="3" class="d-flex align-center">
+                    <v-chip size="large" :color="getColor(data.status)">
+                        <span class="text-h5 chip-text">
+                            {{ getStatusName(data.status) }}
+                        </span>
+                    </v-chip>
+                </v-col>
+                <v-col cols="2">
+                    <v-chip :color="getColor(data.status)" text-color="black" outlined>
+                        <v-icon v-if="data.status == 'ALL'" @click="router.push('/sales/lead/new')">mdi-pencil</v-icon>
+                        <span v-if="data.status != 'ALL'">{{ data.percentage }}%</span>
+                    </v-chip>
+                </v-col>
+                <v-col cols="2" class="text-center">
+                    <v-chip size="large" color="grey lighten-3" text-color="black" outlined>
+                        <span class="text-h5">{{ data.count }} 건</span>
+                    </v-chip>
+                </v-col>
+                <v-col cols="5">
+                    <v-chip color="grey lighten-3" text-color="black" outlined>
+                        <span class="amt">{{ formatNumber(data.amt) }}</span>
+                    </v-chip>
+                </v-col>
+            </v-row>
+        </v-col>
+    </v-row>
+</template>
+
+<style lang="scss" scoped>
+.subtitle {
+    text-align: right;
+}
+
+.chip-text {
+    width: 100px;
+    text-align: center;
+}
+
+.amt {
+    width: 150px;
+    text-align: left;
+}
+</style>

--- a/src/components/lead/Success.vue
+++ b/src/components/lead/Success.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref, computed, watch } from 'vue';
+import { useTheme } from 'vuetify';
+
+const props = defineProps({
+    sucessData: {
+        type: [Object, Function],
+        default: () => ({})
+    }
+});
+
+const theme = useTheme();
+
+const pieChart = ref({
+    series: []
+});
+
+const labels = ref([]);
+
+const piechartOptions = computed(() => {
+    return {
+        chart: {
+            type: 'pie',
+            height: 400,
+            fontFamily: `inherit`,
+            foreColor: '#adb0bb',
+            toolbar: {
+                show: false
+            }
+        },
+        dataLabels: {
+            enabled: true,
+            formatter: function (val, { seriesIndex, w }) {
+                const label = w.config.labels[seriesIndex];
+                return `${val} % (${label})`;
+            }
+        },
+        plotOptions: {
+            pie: {
+                donut: {
+                    size: '70px'
+                }
+            }
+        },
+        legend: {
+            show: true,
+            position: 'bottom',
+            width: '50px'
+        },
+        colors: [
+            '#00129A',
+            '#0023F5',
+            'rgba(var(--v-theme-primary))',
+            '#3282F6',
+            '#9FFCFD',
+            'rgba(var(--v-theme-success))',
+            'rgba(var(--v-theme-secondary))'
+        ],
+        tooltip: {
+            enabled: false,
+            fillSeriesColor: false
+        },
+        stroke: {
+            width: 2,
+            colors: 'rgba(var(--v-theme-surface))'
+        },
+        labels: labels.value, // labels 값을 동적으로 설정
+        responsive: [
+            {
+                breakpoint: 480,
+                options: {
+                    chart: {
+                        width: 200
+                    },
+                    legend: {
+                        position: 'bottom'
+                    }
+                }
+            }
+        ]
+    };
+});
+
+watch(
+    () => props.sucessData,
+    (newSuccessData) => {
+        labels.value = newSuccessData.map((item) => item.successPer + '%');
+        pieChart.value.series = newSuccessData.map((item) => item.count);
+    }
+);
+</script>
+
+<template>
+    <v-row>
+        <v-col cols="12">
+            <apexchart type="pie" height="200" :options="piechartOptions" :series="pieChart.series"> </apexchart>
+        </v-col>
+    </v-row>
+</template>
+
+<style lang="scss" scoped></style>

--- a/src/components/sales/main/Customer.vue
+++ b/src/components/sales/main/Customer.vue
@@ -12,7 +12,7 @@ const props = defineProps({
         <v-divider :thickness="3" class="border-opacity-50 mb-3" color="primary"></v-divider>
         <v-row>
             <v-col cols="12" lg="6">
-                <v-card class="bg-error" elevation="10">
+                <v-card class="bg-primary" elevation="10">
                     <v-card-text class="pa-6">
                         <component :is="UserIcon" stroke-width="1.5" size="25" />
                         <h5 class="text-h5 mt-2 text-white">{{ props.customerCount }}</h5>
@@ -21,7 +21,7 @@ const props = defineProps({
                 </v-card>
             </v-col>
             <v-col cols="12" lg="6">
-                <v-card class="bg-warning" elevation="10">
+                <v-card class="bg-secondary" elevation="10">
                     <v-card-text class="pa-6">
                         <component :is="UserQuestionIcon" stroke-width="1.5" size="25" />
                         <h5 class="text-h5 mt-2 text-white">{{ props.potenCustomerCount }}</h5>

--- a/src/layouts/full/horizontal-sidebar/horizontalItems.ts
+++ b/src/layouts/full/horizontal-sidebar/horizontalItems.ts
@@ -85,14 +85,14 @@ export interface menu {
     class?: string;
     extraclass?: string;
     type?: string;
-    adminOnly?:boolean;
+    adminOnly?: boolean;
 }
 
 const horizontalItems: menu[] = [
     {
         title: 'Home',
         icon: HomeIcon,
-        to: '/sales/main',
+        to: '/sales/main'
     },
     {
         title: '영업기회',
@@ -107,7 +107,7 @@ const horizontalItems: menu[] = [
             {
                 title: '캘린더',
                 icon: CalendarIcon,
-                to: '/apps/calendar',
+                to: '/apps/calendar'
             },
             {
                 title: '할 일',
@@ -123,7 +123,7 @@ const horizontalItems: menu[] = [
                 title: '영업활동',
                 icon: CircleDotIcon,
                 to: '/apps/act/list'
-            },
+            }
         ]
     },
 
@@ -135,13 +135,13 @@ const horizontalItems: menu[] = [
             {
                 title: '고객',
                 icon: CircleDotIcon,
-                to: '/sales/contact',
+                to: '/sales/contact'
             },
             {
                 title: '잠재고객',
                 icon: CircleDotIcon,
                 to: '/sales/prospect'
-            },
+            }
         ]
     },
     {
@@ -168,31 +168,31 @@ const horizontalItems: menu[] = [
                 title: '매출',
                 icon: CircleDotIcon,
                 to: '/apps/sales'
-            },
+            }
         ]
     },
-   
+
     {
         title: '영업도구',
         icon: ToolIcon,
         to: '/',
         children: [
-          {
-              title: '보고',
-              icon: CircleDotIcon,
-              to: '/apps/blog/posts'
-          },
-          {
-              title: '공지',
-              icon: CircleDotIcon,
-              to: '/apps/blog/early-black-friday-amazon-deals-cheap-tvs-headphones'
-          },
-          {
-              title: '영업활동',
-              icon: CircleDotIcon,
-              to: '/apps/act/list'
-          }
-      ]
+            {
+                title: '보고',
+                icon: CircleDotIcon,
+                to: '/apps/blog/posts'
+            },
+            {
+                title: '공지',
+                icon: CircleDotIcon,
+                to: '/apps/blog/early-black-friday-amazon-deals-cheap-tvs-headphones'
+            },
+            {
+                title: '영업활동',
+                icon: CircleDotIcon,
+                to: '/apps/act/list'
+            }
+        ]
     },
     {
         title: '차트',
@@ -200,10 +200,25 @@ const horizontalItems: menu[] = [
         to: '/',
         children: [
             {
+                title: '영업 예측',
+                icon: CircleDotIcon,
+                to: '/apps/chart/lead'
+            },
+            {
+                title: '활동 차트',
+                icon: CircleDotIcon,
+                to: '/apps/chart/act'
+            },
+            {
+                title: '계약 차트',
+                icon: CircleDotIcon,
+                to: '/apps/chart/status'
+            },
+            {
                 title: '매출 차트',
                 icon: CircleDotIcon,
                 to: '/',
-                children:[
+                children: [
                     {
                         title: '매출 현황 차트',
                         icon: ChartAreaIcon,
@@ -220,16 +235,6 @@ const horizontalItems: menu[] = [
                         to: '/apps/chart/sales/pridictions'
                     }
                 ]
-            },
-            {
-                title: '활동 차트',
-                icon: CircleDotIcon,
-                to: '/apps/chart/act'
-            },
-            {
-                title: '계약 차트',
-                icon: CircleDotIcon,
-                to: '/apps/chart/status'
             }
         ]
     },
@@ -238,7 +243,7 @@ const horizontalItems: menu[] = [
         title: '관리자',
         icon: SocialIcon,
         to: '/',
-        adminOnly:true,
+        adminOnly: true,
         children: [
             {
                 title: '부서',
@@ -261,7 +266,7 @@ const horizontalItems: menu[] = [
                 to: '/admin/targetsales'
             }
         ]
-    },
+    }
 ];
 
 export default horizontalItems;

--- a/src/router/MainRoutes.ts
+++ b/src/router/MainRoutes.ts
@@ -33,6 +33,11 @@ const MainRoutes = {
             component: () => import('@/views/apps/lead/LeadDetail.vue')
         },
         {
+            name: 'LeadChart',
+            path: '/apps/chart/lead',
+            component: () => import('@/views/apps/lead/LeadChart.vue')
+        },
+        {
             name: 'SalesNotice',
             path: '/sales/notice',
             component: () => import('@/views/sales/Notice.vue')
@@ -543,73 +548,82 @@ const MainRoutes = {
         },
 
         // -------- 추가 by kuk329 ------------
-      
-          { // 고객
-            name: "Customer",
-            path: "/sales/contact",
-            component: () => import("@/views/apps/customer/Customer.vue"),
-          },
-          { // 고객 등록
-            name: "CustomerAdd",
-            path: "/sales/customer-add",
-            component: () => import("@/views/apps/customer/CustomerAdd.vue"),
-          },
 
-          { // 고객 상세 조회 및 수정
-            name: "CustomerDetail",
-            path: "/sales/customer-detail/:id",
-            component: () => import("@/views/apps/customer/CustomerDetail.vue"),
-            props:true
-          },
+        {
+            // 고객
+            name: 'Customer',
+            path: '/sales/contact',
+            component: () => import('@/views/apps/customer/Customer.vue')
+        },
+        {
+            // 고객 등록
+            name: 'CustomerAdd',
+            path: '/sales/customer-add',
+            component: () => import('@/views/apps/customer/CustomerAdd.vue')
+        },
 
-          { // 잠재고객
+        {
+            // 고객 상세 조회 및 수정
+            name: 'CustomerDetail',
+            path: '/sales/customer-detail/:id',
+            component: () => import('@/views/apps/customer/CustomerDetail.vue'),
+            props: true
+        },
+
+        {
+            // 잠재고객
             name: 'pCustomer',
             path: '/sales/prospect',
-            component: ()=> import('@/views/apps/pCustomer/pCustomer.vue')
-            },
+            component: () => import('@/views/apps/pCustomer/pCustomer.vue')
+        },
 
-          { // 잠재고객 등록
-            name: "pCustomerAdd",
-            path: "/sales/prospect/add",
-            component: ()=> import("@/views/apps/pCustomer/pCustomerAdd.vue")
-          },
+        {
+            // 잠재고객 등록
+            name: 'pCustomerAdd',
+            path: '/sales/prospect/add',
+            component: () => import('@/views/apps/pCustomer/pCustomerAdd.vue')
+        },
 
-          { // 잠재고객 상세 조회 및 수정
-            name: "pCustomerDetail",
-            path: "/sales/prospect/:id",
-            component: ()=> import("@/views/apps/pCustomer/pCustomerDetail.vue")
-          },
+        {
+            // 잠재고객 상세 조회 및 수정
+            name: 'pCustomerDetail',
+            path: '/sales/prospect/:id',
+            component: () => import('@/views/apps/pCustomer/pCustomerDetail.vue')
+        },
 
-   
-          { // 부서
-            name: "Department",
-            path: "/admin/departments",
-            component: () => import("@/views/apps/department/Department.vue"),
-            props:true
-          },
+        {
+            // 부서
+            name: 'Department',
+            path: '/admin/departments',
+            component: () => import('@/views/apps/department/Department.vue'),
+            props: true
+        },
 
-          { // 제품
-            name: "Product",
-            path: "/admin/products",
-            component: () => import("@/views/apps/product/Product.vue"),
-            props:true,
-            meta:{requiresAdmin:true}
-          },
-          { // 프로세스
-            name: "Process",
-            path: "/admin/processes",
-            component: () => import("@/views/apps/process/Process.vue"),
-            props:true,
-            meta:{requiresAdmin:true}
-          },
-          
-          { // 목표 매출
-            name: "TargetSale",
-            path: "/admin/targetsales",
-            component: () => import("@/views/apps/targetSale/TargetSale.vue"),
-            props:true,
-            meta:{requiresAdmin:true}
-          },
+        {
+            // 제품
+            name: 'Product',
+            path: '/admin/products',
+            component: () => import('@/views/apps/product/Product.vue'),
+            props: true,
+            meta: { requiresAdmin: true }
+        },
+        {
+            // 프로세스
+            name: 'Process',
+            path: '/admin/processes',
+            component: () => import('@/views/apps/process/Process.vue'),
+            props: true,
+            meta: { requiresAdmin: true }
+        },
+
+        {
+            // 목표 매출
+            name: 'TargetSale',
+            path: '/admin/targetsales',
+            component: () => import('@/views/apps/targetSale/TargetSale.vue'),
+            props: true,
+            meta: { requiresAdmin: true }
+        },
 
         {
             name: 'Material',
@@ -640,9 +654,8 @@ const MainRoutes = {
             name: 'SalesPridictionsChart',
             path: '/apps/chart/sales/pridictions',
             component: () => import('@/views/apps/sales/SalesPredictionChartView.vue')
-        }
-
-        ,   {
+        },
+        {
             name: 'MyPage',
             path: '/apps/user/mypage',
             component: () => import('@/views/apps/user/MyPage.vue')
@@ -677,9 +690,7 @@ const MainRoutes = {
             name: 'SalesEdit',
             path: '/apps/sales/editer/:salesNo',
             component: () => import('@/views/apps/sales/SalesEdit.vue')
-        },
-
-
+        }
     ]
 };
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -7,29 +7,30 @@ const baseUrl = `${import.meta.env.VITE_API_URL}/users`;
 export const useAuthStore = defineStore({
     id: 'auth',
     state: () => ({
-      //  isLoggedIn:localStorage.getItem('isLoggedIn')=='true',
+        //  isLoggedIn:localStorage.getItem('isLoggedIn')=='true',
         // initialize state from local storage to enable user to stay logged in
         // @ts-ignore
         name: localStorage.getItem('loginUserName'),
-        email : localStorage.getItem('loginUserEmail'),
-      //  dept : localStorage.getItem('loginUserDept'),
+        email: localStorage.getItem('loginUserEmail'),
+        //  dept : localStorage.getItem('loginUserDept'),
         user: localStorage.getItem('loginUserName'),
         // role: localStorage.getItem("loginUserRole")||"USER",
         returnUrl: null
     }),
     actions: {
-        setIsLogedIn(){
-            localStorage.setItem('isLoggedIn','true');
+        setIsLogedIn() {
+            localStorage.setItem('isLoggedIn', 'true');
         },
-        
+
         logout() {
             this.user = null;
+            localStorage.removeItem('loginUserNo');
+            localStorage.removeItem('loginDeptNo');
             localStorage.removeItem('loginUserName');
             localStorage.removeItem('loginUserEmail');
             localStorage.removeItem('accessToken');
-            localStorage.setItem('isLoggedIn','false');
-            localStorage.removeItem("loginUserRole"),
-            router.push({name:"Login"});
+            localStorage.setItem('isLoggedIn', 'false');
+            localStorage.removeItem('loginUserRole'), router.push({ name: 'Login' });
         }
     }
 });

--- a/src/views/apps/lead/LeadChart.vue
+++ b/src/views/apps/lead/LeadChart.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { ref, reactive, watch, onMounted } from 'vue';
+import api from '@/api/axiosinterceptor';
+import UiParentCard from '@/components/shared/UiParentCard.vue';
+import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
+
+import Month from '@/components/lead/Month.vue';
+import Status from '@/components/lead/Status.vue';
+import Process from '@/components/lead/Process.vue';
+import Path from '@/components/lead/Path.vue';
+import Success from '@/components/lead/Success.vue';
+
+const userRole = ref(true);
+
+const page = ref({ title: '차트' });
+const breadcrumbs = ref([
+    { text: '차트', disabled: false, href: '#' },
+    { text: '영업 예측', disabled: true, href: '#' }
+]);
+
+const today = new Date();
+const year = today.getFullYear();
+const firstDayOfYear = new Date(Date.UTC(year, 0, 1, 0, 0, 0));
+firstDayOfYear.setHours(firstDayOfYear.getHours() + 3);
+const lastDayOfYear = new Date(Date.UTC(year, 11, 31, 3, 0, 0));
+const searchStartDate = ref(firstDayOfYear.toISOString().substring(0, 10));
+const searchEndDate = ref(lastDayOfYear.toISOString().substring(0, 10));
+
+const selectedDept = ref(0);
+const selectedManager = ref(0);
+const state = reactive({
+    departments: [],
+    managers: []
+});
+
+const searchCond = reactive({
+    startDate: searchStartDate.value,
+    endDate: searchEndDate.value,
+    deptNo: selectedManager.value,
+    userNo: selectedManager.value
+});
+
+const isMounted = ref(false);
+
+const monthData = reactive([]);
+const statusData = reactive([]);
+const processData = reactive([]);
+const pathData = reactive([]);
+const sucessData = reactive([]);
+
+const fetchDept = async () => {
+    try {
+        const response = await api.get(`/admin/departments`);
+
+        state.departments = [{ no: 0, name: '전체' }, ...response.data.result];
+
+        if (response.data.isSuccess) {
+            if (userRole.value) {
+                const deptNo = localStorage.getItem('loginDeptNo');
+                selectedDept.value = deptNo ? Number(deptNo) : 0;
+            }
+
+            fetchUser(selectedDept.value);
+        }
+    } catch (error) {
+        console.error('부서 데이터를 불러오는 중 오류가 발생했습니다:', error);
+    }
+};
+
+const fetchUser = async (deptNo) => {
+    try {
+        let response;
+
+        if (deptNo != null && deptNo > 1 && deptNo != 'undefined') {
+            response = await api.get(`/users/by-dept/${deptNo}`);
+
+            state.managers = [{ userNo: 0, name: '전체' }, ...response.data.result];
+
+            if (response.data.isSuccess) {
+                if (userRole.value) {
+                    const userNo = localStorage.getItem('loginUserNo');
+                    selectedManager.value = userNo ? Number(userNo) : 0;
+                }
+            }
+        } else {
+            state.managers = [{ userNo: 0, name: '전체' }];
+        }
+
+        if (!isMounted.value) {
+            fetchData();
+        }
+        isMounted.value = true;
+    } catch (error) {
+        console.error('user 데이터를 불러오는 중 오류가 발생했습니다.');
+    }
+};
+
+const fetchData = async () => {
+    try {
+        const [monthRes, statusRes, pathRes, sucessRes] = await Promise.all([
+            api.post('/leads/chart/month', searchCond),
+            api.post('/leads/status/main', searchCond),
+            // api.post('/leads/chart/process', searchCond),
+            api.post('/leads/chart/path', searchCond),
+            api.post('/leads/chart/success', searchCond)
+        ]);
+
+        monthData.values = monthRes.data.result;
+        statusData.values = statusRes.data.result;
+        pathData.values = pathRes.data.result;
+        sucessData.values = sucessRes.data.result;
+
+        // console.log(statusData.values);
+    } catch (error) {
+        console.error('Error fetching data:', error);
+    }
+};
+
+watch(selectedDept, (newDept) => {
+    if (newDept != null) {
+        searchCond.deptNo = newDept;
+        selectedManager.value = 0;
+        fetchUser(newDept);
+    }
+});
+
+watch(searchStartDate, (newDate) => {
+    searchCond.startDate = newDate;
+});
+
+watch(searchEndDate, (newDate) => {
+    searchCond.endDate = newDate;
+});
+
+watch(selectedManager, (newUser) => {
+    searchCond.userNo = newUser;
+});
+
+onMounted(() => {
+    if (localStorage.getItem('loginUserRole') == 'ADMIN') {
+        userRole.value = false;
+    }
+
+    fetchDept();
+});
+</script>
+
+<template>
+    <BaseBreadcrumb :title="page.title" :breadcrumbs="breadcrumbs"></BaseBreadcrumb>
+    <v-container fluid>
+        <v-row>
+            <v-col cols="12" md="2">
+                <v-card elevation="0" class="pa-4">
+                    <v-card-title class="title font-weight-bold">검색 조건</v-card-title>
+                    <v-text-field label="시작일자" v-model="searchStartDate" type="date" outlined></v-text-field>
+                    <v-text-field label="종료일자" v-model="searchEndDate" type="date" outlined></v-text-field>
+                    <v-select
+                        label="부서"
+                        v-model="selectedDept"
+                        :items="state.departments"
+                        item-props="true"
+                        item-title="name"
+                        item-value="no"
+                        outlined
+                        :disabled="userRole"
+                    ></v-select>
+                    <v-select
+                        label="담당자"
+                        v-model="selectedManager"
+                        :items="state.managers"
+                        item-props="true"
+                        item-title="name"
+                        item-value="userNo"
+                        outlined
+                        :disabled="userRole"
+                    ></v-select>
+                    <v-btn class="search_btn" color="primary" variant="flat" @click="fetchData">검색</v-btn>
+                </v-card>
+            </v-col>
+            <v-col cols="12" md="10">
+                <v-row>
+                    <v-col cols="12">
+                        <UiParentCard title="월별 현황">
+                            <Month :month-data="monthData.values" />
+                        </UiParentCard>
+                    </v-col>
+                    <!-- <v-col cols="12" lg="6">
+                        <UiParentCard title="프로세스">
+                            <Process />
+                        </UiParentCard>
+                    </v-col> -->
+                    <v-col cols="12" lg="6">
+                        <UiParentCard title="진행상태">
+                            <Status :status-data="statusData.values" />
+                        </UiParentCard>
+                    </v-col>
+                    <v-col cols="12" lg="6">
+                        <UiParentCard title="성공확률">
+                            <Success :sucess-data="sucessData.values" />
+                        </UiParentCard>
+                    </v-col>
+                    <v-col cols="12">
+                        <UiParentCard title="인지경로">
+                            <Path :path-data="pathData.values" />
+                        </UiParentCard>
+                    </v-col>
+                </v-row>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>
+
+<style lang="scss"></style>


### PR DESCRIPTION
close #127

## 💬 작업 내용 설명
> 영업 예측 페이지 추가 - View : LeadChart, Component : Month, Path, Process, Status, Success
로그인 시 로컬스토리지 userNo, deptNo 저장 추가
로그아웃 시 로컬스토리지 userNo, deptNo 삭제 추가
lead 상세 조회 페이지 단위 추가
메인 - 색상 수정
권한에 따른 부서 및 담당자 설정 추가 - 메인, 영업기회, 영업예측 조회

<br>

## #️⃣연관된  issue
#127 

<br>

## ✅ 체크리스트
- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
