### PR TITLE
[Feat/#193] 전사일정 구현 및 캘린더 에러 수정

### DIFF
--- a/src/components/modal/PlanModal.vue
+++ b/src/components/modal/PlanModal.vue
@@ -26,16 +26,16 @@
 							></v-select>
 						</v-col>
 						<v-col cols="12" v-if="plan.planCls && !['개인', '전사'].includes(this.plan.planCls)">
-							<v-text-field 
-								v-model="planDetails.title" 
-								:label="dynamicTitleLabel" 
-								readonly
-							></v-text-field>
-							<v-text-field 
-								v-model="planDetails.note" 
-								:label="dynamicNoteLabel" 
-								readonly
-							></v-text-field>
+              <v-text-field 
+                v-model="plan.planDetails.title" 
+                :label="dynamicTitleLabel" 
+                readonly
+              ></v-text-field>
+              <v-text-field 
+                v-model="plan.planDetails.note" 
+                :label="dynamicNoteLabel" 
+                readonly
+              ></v-text-field>
 						</v-col>
 						<v-col cols="12">
 							<v-text-field v-model="plan.planDate" label="일자*" type="date" 
@@ -125,6 +125,7 @@ export default {
 	props: {
 		AddPlanModal: Boolean,
 		plan: Object,
+    planDetails: Object,
 		statusOptions: Array,
 		planClsOptions: Array,
 		mode: {
@@ -242,14 +243,38 @@ export default {
 				this.domainList = [];
 			}
 		},
-		selectDomain(item) {
-			this.planDetails = {
-				title: item[this.titleField] || '',
-				note: item[this.noteField] || '',
-			};	
-			this.isSelected = false;
-			this.domainList = [];
-		},
+
+    selectDomain(item) {
+      console.log("item:", item);
+
+      this.planDetails = {
+        title: item[this.titleField] || '',
+        note: item[this.noteField] || '',
+      };
+
+      switch (this.plan.planCls) {
+        case '계약':
+          this.plan.domainNo = item.contractNo;
+          break;
+        case '매출':
+          this.plan.domainNo = item.salesNo;
+          break;
+        case '견적':
+          this.plan.domainNo = item.estNo;
+          break;
+        case '제안':
+          this.plan.domainNo = item.propNo;
+          break;
+        default:
+          this.plan.domainNo = null;
+      }
+
+      console.log("Selected domainNo:", this.plan.domainNo);
+
+      this.isSelected = false;
+      this.domainList = [];
+    },
+
 		generateTimeOptions() {
 			const options = [];
 			for (let hour = 0; hour < 24; hour++) {
@@ -292,12 +317,17 @@ export default {
 				this.plan.backgroundColor = categoryColor;
 				const response = await api.patch(`/plans/${this.plan.planNo}`, this.plan);
 				const updatedPlan = response.data.result;
+
+				this.closeModal();
+        setTimeout(() => {
+          window.location.reload();
+          }, 1000);
+          
 				this.$emit('show-alert', {
 					message: '일정이 수정되었습니다.',
 					type: 'success',
 				});
 				this.$emit('update', updatedPlan);
-				this.closeModal();
 			} catch (error) {
 				console.error(error);
 			}

--- a/src/components/modal/TodoModal.vue
+++ b/src/components/modal/TodoModal.vue
@@ -69,13 +69,21 @@ export default {
 	},
 	data() {
 		return {
-      priorityOptions: ['높음', '중간', '낮음'],
+      		priorityOptions: ['높음', '중간', '낮음'],
 			showAlert: false,
 			showSuccessAlert: false,
 			showConfirmDialogs: false,
 			alertMessage: '',
 			alertType: '',
 			isPrivate: this.todo.privateYn === 'Y',
+			statusMapping: {
+				"진행 전": "TODO",
+				"진행 중": "INPROGRESS",
+				"완료": "DONE",
+				"TODO": "진행 전",
+				"INPROGRESS": "진행 중",
+				"DONE": "완료"
+			},
 		};
 	},
 	watch: {
@@ -91,6 +99,9 @@ export default {
 	},
 	
 	methods: {
+		mapStatusToEnum(status) {
+			return this.statusMapping[status] || status;
+		},
     validateTodo() {
 			const isValid = this.$refs.form.validate();
       if (!this.todo.title || !this.todo.todoCls || !this.todo.priority || !this.todo.dueDate || !this.todo.status) {
@@ -122,9 +133,13 @@ export default {
 			if (!this.validateTodo()) {
 				return;
 			}
+			const todoData = {
+				...this.todo,
+				status: this.mapStatusToEnum(this.todo.status),
+			};
 
 			try {
-				const response = await api.patch(`/todos/${this.todo.todoNo}`, this.todo);
+				const response = await api.patch(`/todos/${this.todo.todoNo}`, todoData);
 				const updatedTodo = response.data.result;
 
 				this.$emit('update', updatedTodo);

--- a/src/stores/apps/calendar/calendarStore.js
+++ b/src/stores/apps/calendar/calendarStore.js
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia';
+import api from '@/api/axiosinterceptor';
+
+export const useCompanyCalendarStore = defineStore('companyCalendar', {
+  state: () => ({
+    events: [],//todo + plan
+    showCompanyEvents: false,
+  }),
+  
+  actions: {
+    // 전사일정 가져오기
+    async fetchCompanyEvents() {
+      try {
+        const response = await api.get('/company/calendars');
+        console.log('response',response)
+        if (response.data.isSuccess) {
+          const { plans, todos } = response.data.result;
+
+          const planEvents = plans.map(plan => ({
+            id: `plan-${plan.planNo}`,
+            title: plan.title,
+            start: plan.planDate + 'T' + plan.startTime,
+            end: plan.planDate + 'T' + plan.endTime,
+            extendedProps: {...plan },
+            classNames: ['company_plan-event'],
+          }));
+
+          const todoEvents = todos.map(todo => ({
+            id: `todo-${todo.todoNo}`,
+            title: todo.title,
+            start: todo.dueDate,
+            extendedProps: {...todo },
+            classNames: ['todo-event'],
+          }));
+
+          this.events = [...planEvents, ...todoEvents];
+        }
+      } catch (error) {
+        console.error('Failed to fetch company events:', error);
+      }
+    },
+    
+    // 전사일정 토글 상태 변경
+    toggleCompanyEvents() {
+      this.showCompanyEvents = !this.showCompanyEvents;
+      
+      if (this.showCompanyEvents) {
+        this.fetchCompanyEvents();
+      } else {
+        this.events = [];
+      }
+    },
+  },
+});

--- a/src/utils/PlanMappings.js
+++ b/src/utils/PlanMappings.js
@@ -40,5 +40,5 @@ export const chipColors = {
   'PROPOSAL': { color: '#58b070', text: '#000' },
   'ESTIMATE': { color: '#9ea7b3', text: '#000' },
   'SALES': { color: '#5b8db8', text: '#000' },
-  'CONTRACT': { color: '#3498db', text: '#fff' }
+  'CONTRACT': { color: '#8bafc5', text: '#fff' }
 };

--- a/src/views/apps/calendar/CalendarFilters.vue
+++ b/src/views/apps/calendar/CalendarFilters.vue
@@ -10,9 +10,9 @@ const categoryColors = {
   personal_plan: { color: '#f7eaa4', label: '개인 일정' },
   company_plan: { color: '#dde2a9', label: '전사 일정' },
   proposal_plan: { color: '#9ed7a9', label: '제안' },
-  contract_plan: { color: '#a4cbe8', label: '계약' },
+  act: { color: '#a4cbe8', label: '영업 활동' },
   sales_plan: { color: '#a4bbe1', label: '매출' },
-  act: { color: '#a9acd8', label: '영업 활동' },
+  contract_plan: { color: '#8bafc5', label: '계약' },
   estimate_plan: { color: '#ccd5db', label: '견적' },
 };
 

--- a/src/views/apps/calendar/FullCalender.vue
+++ b/src/views/apps/calendar/FullCalender.vue
@@ -532,7 +532,13 @@ export default defineComponent({
 
       <FullCalendar ref="calendar" class='demo-app-calendar rounded-md':options="calendarOptions">
         <template v-slot:eventContent="arg">
-          <div class="text-subtitle-1 pa-1 text-truncate">{{ arg.event.title }}</div>
+          <!-- <div class="text-subtitle-1 pa-1 text-truncate">{{ arg.event.title }}</div> -->
+          <div class="event-content">
+            <span v-if="arg.event.start && arg.event.startStr.includes('T')" class="event-time">
+              {{ arg.event.startStr.split('T')[1].slice(0, 5) }}
+            </span>
+            <span class="event-title">{{ arg.event.title }}</span>
+          </div>
         </template>
       </FullCalendar>
 
@@ -586,5 +592,16 @@ export default defineComponent({
 .label-bold .v-input__control .v-label {
   font-size: 14px;
   font-weight: bold;
+}
+
+.event-time {
+  font-weight: bold;
+  font-size: 15px;
+}
+.event-title {
+  margin-left: 5px;
+  font-size: 15px;
+  font-weight: bold;
+
 }
 </style>

--- a/src/views/apps/calendar/calendar.css
+++ b/src/views/apps/calendar/calendar.css
@@ -10,18 +10,26 @@
   cursor: pointer;
   border: none;
 }
+.todo-event .event-time::before {
+  color: white;
+  font-weight: bold;
+}
 
 /* 영업활동 */
 .act-event {
-  background-color: #a9acd8;
+  background-color: #a4cbe8;
   color: white;
   font-size: 14px;
   border: none;
 }
 .act-event:hover {
-  background-color: #9da1d1;
+  background-color: #95bfdf;
   cursor: pointer;
   border: none;
+}
+.act-event .event-time::before {
+  color: white;
+  font-weight: bold;
 }
 
 /* 개인 일정 */
@@ -35,6 +43,11 @@
   background-color: #ebde8f;
   color: #555555;
 }
+.personal_plan-event .event-time::before {
+  color: #555555;
+  font-weight: bold;
+}
+
 
 /* 전사 일정 */
 .company_plan-event {
@@ -46,6 +59,10 @@
 .company_plan-event:hover {
   background-color: #d8de98; 
   color: white;
+}
+.company_plan-event .event-time::before {
+  color: #555555;
+  font-weight: bold;
 }
 
 /* 제안 */
@@ -60,18 +77,27 @@
   cursor: pointer;
   border: none;
 }
+.proposal_plan-event .event-time::before {
+  color: white;
+  font-weight: bold;
+}
+
 
 /* 계약 */
 .contract_plan-event {
-  background-color: #a4cbe8;
+  background-color: #8bafc5;
   color: white;
   font-size: 14px;
   border: none;
 }
 .contract_plan-event:hover {
-  background-color: #95bfdf;
+  background-color: rgb(123, 162, 187);
   cursor: pointer;
   border: none;
+}
+.contract_plan-event .event-time::before {
+  color: white;
+  font-weight: bold;
 }
 
 /* 매출 */
@@ -86,6 +112,10 @@
   cursor: pointer;
   border: none;
 }
+.sales_plan-event .event-time::before {
+  color: white;
+  font-weight: bold;
+}
 
 /* 견적 */
 .estimate_plan-event {
@@ -99,6 +129,15 @@
   cursor: pointer;
   border: none;
 }
+.estimate_plan-event .event-time::before {
+  color: #686565;
+  font-weight: bold;
+}
+.fc-event {
+  padding: 4px 0;
+  min-height: 20px;
+}
+
 
 .fc-event-title {
   font-weight: bold;
@@ -112,4 +151,10 @@
 
 .fc-toolbar button:hover {
   background-color: #2a4887;
+}
+.event-time::before {
+  content: "|";
+  margin-right: 3px;
+  margin-left: 4px;
+  font-weight: bold;
 }


### PR DESCRIPTION
## 💬 작업 내용 설명
- 전사일정 구현 
- 캘린더 이벤트 제목에 시간 추가
- 기타 스타일 수정
- 캘린더 오류 수정
   - plan 수정, 삭제 reloading 문제
   - plan 상세 조회 시 도메인 세부 정보 조회 x 문제
   - todo 한글 매핑

<br>

<details>
  <summary> 전사일정 off</summary>

![image](https://github.com/user-attachments/assets/5e5d8778-34a0-4404-86b4-e54d91f034cb)

</details>
<details>
  <summary> 전사일정 on</summary>

![image](https://github.com/user-attachments/assets/bfe5a0ea-7d45-45d7-bbb3-7a0c602ca8ec)
</details>

<br>

## #️⃣연관된  issue
close #191 
close #193

<br>

## ✅ 체크리스트
- [X] 새로운 기능 추가
- [X] 버그 수정

<br>
